### PR TITLE
feat: add one-page listing template

### DIFF
--- a/include/options-config.php
+++ b/include/options-config.php
@@ -2223,8 +2223,10 @@ Redux::setSection($opt_name, array(
             'compiler' => 'true',
             'options' => array(
                 'general' => array(
-                    'lp_video_section' => 'Youtube Video',
+                    'lp_video_section' => 'Video',
                     'lp_content_section' => 'Details',
+                    'lp_services_section' => 'Services',
+                    'lp_gallery_section' => 'Resim',
                     // New update 2.8                    // 'lp_openFields_section' => 'Listing Global Form Fields',
                     // End New update 2.8
                     'lp_features_section' => 'Listing Features',

--- a/include/options-config.php
+++ b/include/options-config.php
@@ -2214,6 +2214,58 @@ Redux::setSection($opt_name, array(
                 ),
             ),
         ),
+        array(
+            'id' => 'lp-detail-page-layout6-content',
+            'type' => 'sorter',
+            'title' => 'Content Layout',
+            'required' => array('lp_detail_page_styles', 'equals', 'lp_detail_page_styles6'),
+            'desc' => 'Shuffle elements within Listing Detail Content',
+            'compiler' => 'true',
+            'options' => array(
+                'general' => array(
+                    'lp_video_section' => 'Youtube Video',
+                    'lp_content_section' => 'Details',
+                    // New update 2.8                    // 'lp_openFields_section' => 'Listing Global Form Fields',
+                    // End New update 2.8
+                    'lp_features_section' => 'Listing Features',
+                    'lp_additional_section' => 'Additional Details',
+                    'lp_faqs_section' => 'FAQs',
+                    'lp_event_section' => 'Event',
+                    'lp_announcements_section' => 'Announcements',
+                    'lp_offers_section' => 'Offers/Discounts/Deals',
+                    'lp_menu_section' => 'Menu',
+                    'lp_reviews_section' => 'Reviews',
+                    'lp_reviewform_section' => 'Review Form',
+                ),
+                'disabled' => array(
+                    '' => '',
+                ),
+            ),
+        ),
+        array(
+            'id' => 'lp-detail-page-layout6-rsidebar',
+            'type' => 'sorter',
+            'title' => 'Sidebar Layout',
+            'required' => array('lp_detail_page_styles', 'equals', 'lp_detail_page_styles6'),
+            'desc' => 'Shuffle elements within Listing SideBar',
+            'compiler' => 'true',
+            'options' => array(
+                'sidebar' => array(
+                    'lp_mapsocial_section' => 'Map/Contacts',
+                    'lp_event_section' => 'Event',
+                    'lp_booking_section' => 'Appointments',
+                    'lp_timing_section' => 'Timings',
+                    'lp_quicks_section' => 'Quick Actions',
+                    'lp_additional_section' => 'Additional Details',
+                    'lp_offers_section' => 'Offers/Discounts/Deals',
+                    'lp_leadform_section' => 'Leadform',
+                    'lp_sidebarelemnts_section' => 'Detail Page Sidebar Widgets',
+                ),
+                'disabled' => array(
+                    '' => '',
+                ),
+            ),
+        ),
         /* for listing layout3 & 4 */
         array(
             'id' => 'lp-detail-page-layout4-content',
@@ -2429,59 +2481,6 @@ Redux::setSection($opt_name, array(
                     'lp_quicks_section' => 'Quick Actions',
                     'lp_additional_section' => 'Additional Details',
                     'lp_offers_section' => 'Offers/Discounts/Deals',
-                    'lp_sidebarelemnts_section' => 'Detail Page Sidebar Widgets',
-                ),
-                'disabled' => array(
-                    '' => '',
-                ),
-            ),
-        ),
-		//classic new style
-		array(
-            'id' => 'lp-detail-page-layout6-content',
-            'type' => 'sorter',
-            'title' => 'Content Layout',
-            'required' => array('lp_detail_page_styles', 'equals', 'lp_detail_page_styles6'),
-            'desc' => 'Shuffle elements within Listing Detail Content',
-            'compiler' => 'true',
-            'options' => array(
-                'general' => array(
-                    'lp_video_section' => 'Youtube Video',
-                    'lp_content_section' => 'Details',
-                    // New update 2.8                    // 'lp_openFields_section' => 'Listing Global Form Fields',
-                    // End New update 2.8
-                    'lp_features_section' => 'Listing Features',
-                    'lp_additional_section' => 'Additional Details',
-                    'lp_faqs_section' => 'FAQs',
-                    'lp_event_section' => 'Event',
-                    'lp_announcements_section' => 'Announcements',
-                    'lp_offers_section' => 'Offers/Discounts/Deals',
-                    'lp_menu_section' => 'Menu',
-                    'lp_reviews_section' => 'Reviews',
-                    'lp_reviewform_section' => 'Review Form',
-                ),
-                'disabled' => array(
-                    '' => '',
-                ),
-            ),
-        ),
-        array(
-            'id' => 'lp-detail-page-layout6-rsidebar',
-            'type' => 'sorter',
-            'title' => 'Sidebar Layout',
-            'required' => array('lp_detail_page_styles', 'equals', 'lp_detail_page_styles6'),
-            'desc' => 'Shuffle elements within Listing SideBar',
-            'compiler' => 'true',
-            'options' => array(
-                'sidebar' => array(
-                    'lp_mapsocial_section' => 'Map/Contacts',
-                    'lp_event_section' => 'Event',
-                    'lp_booking_section' => 'Appointments',
-                    'lp_timing_section' => 'Timings',
-                    'lp_quicks_section' => 'Quick Actions',
-                    'lp_additional_section' => 'Additional Details',
-                    'lp_offers_section' => 'Offers/Discounts/Deals',
-                    'lp_leadform_section' => 'Leadform',
                     'lp_sidebarelemnts_section' => 'Detail Page Sidebar Widgets',
                 ),
                 'disabled' => array(

--- a/include/options-config.php
+++ b/include/options-config.php
@@ -2181,14 +2181,14 @@ Redux::setSection($opt_name, array(
             'id' => 'lp_detail_page_styles',
             'type' => 'select',
             'title' => __('Select listing detail page Style', 'listingpro'),
-            'desc' => __('Choose from 1 of 4 styles.', 'listingpro'),
+            'desc' => __('Choose from the available styles.', 'listingpro'),
             'options' => array(
                 'lp_detail_page_styles1' => 'Listing Detail Page Style 1',
                 'lp_detail_page_styles2' => 'Listing Detail Page Style 2',
                 'lp_detail_page_styles3' => 'Listing Detail Page Style 3',
                 'lp_detail_page_styles4' => 'Listing Detail Page Style 4',
-				'lp_detail_page_styles6' => 'Listing Detail Page Style 5' //classic new style
-                /* 'lp_detail_page_styles5' => 'Listing Detail Page Style 5', */
+                'lp_detail_page_styles5' => 'Listing Detail Page Style 5',
+                'lp_detail_page_styles6' => 'Listing Detail Page Style 6 (One Page)',
             ),
             'default' => 'lp_detail_page_styles1',
         ),
@@ -2505,7 +2505,7 @@ Redux::setSection($opt_name, array(
             'id' => 'lp_detail_page_video_display',
             'type' => 'button_set',
             'title' => esc_html__('Video Display Option', 'listingpro'),
-            'required' => array('lp_detail_page_styles', 'equals', array('lp_detail_page_styles6', 'lp_detail_page_styles1')), //classic new style
+            'required' => array('lp_detail_page_styles', 'equals', array('lp_detail_page_styles5', 'lp_detail_page_styles1')), //classic new style
             'subtitle' => esc_html__('On=Show youtube video in popup, off=embed', 'listingpro'),
             'options' => array(
                 'on' => 'On',
@@ -2549,7 +2549,7 @@ Redux::setSection($opt_name, array(
             'title' => esc_html__('Discount/Deals (sidebar)', 'listingpro'),
             'subtitle' => esc_html__('design for sidebar area', 'listingpro'),
             'desc' => esc_html__('The design used when deals show within the sidebar.', 'listingpro'),
-            'required' => array('lp_detail_page_styles', 'equals', array('lp_detail_page_styles4', 'lp_detail_page_styles3', 'lp_detail_page_styles2', 'lp_detail_page_styles1' , 'lp_detail_page_styles6')), //classic new style
+            'required' => array('lp_detail_page_styles', 'equals', array('lp_detail_page_styles4', 'lp_detail_page_styles3', 'lp_detail_page_styles2', 'lp_detail_page_styles1' , 'lp_detail_page_styles5')), //classic new style
             'options' => array(
                 '1' => array(
                     'alt' => 'Deals Design',

--- a/include/setup/content/classic-x/themeOptions.json
+++ b/include/setup/content/classic-x/themeOptions.json
@@ -343,8 +343,10 @@
     "lp-detail-page-layout6-content": {
         "general": {
             "placebo": "placebo",
-            "lp_video_section": "Youtube Video",
+            "lp_video_section": "Video",
             "lp_content_section": "Details",
+            "lp_services_section": "Services",
+            "lp_gallery_section": "Resim",
             "lp_features_section": "Listing Features",
             "lp_additional_section": "Additional Details",
             "lp_faqs_section": "FAQs",

--- a/include/setup/content/classic-x/themeOptions.json
+++ b/include/setup/content/classic-x/themeOptions.json
@@ -340,6 +340,44 @@
             "0": ""
         }
     },
+    "lp-detail-page-layout6-content": {
+        "general": {
+            "placebo": "placebo",
+            "lp_video_section": "Youtube Video",
+            "lp_content_section": "Details",
+            "lp_features_section": "Listing Features",
+            "lp_additional_section": "Additional Details",
+            "lp_faqs_section": "FAQs",
+            "lp_event_section": "Event",
+            "lp_announcements_section": "Announcements",
+            "lp_offers_section": "Offers\/Discounts\/Deals",
+            "lp_menu_section": "Menu",
+            "lp_reviews_section": "Reviews",
+            "lp_reviewform_section": "Review Form"
+        },
+        "disabled": {
+            "placebo": "placebo",
+            "0": ""
+        }
+    },
+    "lp-detail-page-layout6-rsidebar": {
+        "sidebar": {
+            "placebo": "placebo",
+            "lp_mapsocial_section": "Map\/Contacts",
+            "lp_event_section": "Event",
+            "lp_booking_section": "Appointments",
+            "lp_timing_section": "Timings",
+            "lp_quicks_section": "Quick Actions",
+            "lp_additional_section": "Additional Details",
+            "lp_offers_section": "Offers\/Discounts\/Deals",
+            "lp_leadform_section": "Leadform",
+            "lp_sidebarelemnts_section": "Detail Page Sidebar Widgets"
+        },
+        "disabled": {
+            "placebo": "placebo",
+            "0": ""
+        }
+    },
     "lp-detail-page-layout4-content": {
         "general": {
             "placebo": "placebo",
@@ -495,44 +533,6 @@
             "lp_event_section": "Event",
             "lp_offers_section": "Offers\/Discounts\/Deals",
             "lp_booking_section": "Appointments"
-        }
-    },
-    "lp-detail-page-layout6-content": {
-        "general": {
-            "placebo": "placebo",
-            "lp_video_section": "Youtube Video",
-            "lp_content_section": "Details",
-            "lp_features_section": "Listing Features",
-            "lp_additional_section": "Additional Details",
-            "lp_faqs_section": "FAQs",
-            "lp_reviews_section": "Reviews",
-            "lp_announcements_section": "Announcements",
-            "lp_reviewform_section": "Review Form",
-            "lp_event_section": "Event",
-            "lp_menu_section": "Menu",
-            "lp_offers_section": "Offers\/Discounts\/Deals"
-        },
-        "disabled": {
-            "placebo": "placebo",
-            "0": ""
-        }
-    },
-    "lp-detail-page-layout6-rsidebar": {
-        "sidebar": {
-            "placebo": "placebo",
-            "lp_timing_section": "Timings",
-            "lp_mapsocial_section": "Map\/Contacts",
-            "lp_additional_section": "Additional Details",
-            "lp_leadform_section": "Leadform",
-            "lp_booking_section": "Appointments",
-            "lp_quicks_section": "Quick Actions",
-            "lp_offers_section": "Offers\/Discounts\/Deals",
-            "lp_event_section": "Event",
-            "lp_sidebarelemnts_section": "Detail Page Sidebar Widgets"
-        },
-        "disabled": {
-            "placebo": "placebo",
-            "0": ""
         }
     },
     "lp_detail_page_additional_styles": "right",

--- a/include/setup/content/classic-x/themeOptions.json
+++ b/include/setup/content/classic-x/themeOptions.json
@@ -323,7 +323,7 @@
         "width": "",
         "thumbnail": ""
     },
-    "lp_detail_page_styles": "lp_detail_page_styles6",
+    "lp_detail_page_styles": "lp_detail_page_styles5",
     "lp-detail-page-layout5-content": {
         "general": {
             "placebo": "placebo",

--- a/single-listing.php
+++ b/single-listing.php
@@ -52,14 +52,13 @@
 		{
 			get_template_part( 'templates/listing-style4' );
 		}
-		else if( $lp_detail_page_styles == 'lp_detail_page_styles5' )
-		{
-			get_template_part( 'templates/listing_detail5' );
-		}else if( $lp_detail_page_styles == 'lp_detail_page_styles6' ) {
-		   get_template_part( 'templates/listing-detail6' ); //classic new style
-		}
+               else if( $lp_detail_page_styles == 'lp_detail_page_styles5' ) {
+                  get_template_part( 'templates/listing_detail5' );
+               }
+               else if( $lp_detail_page_styles == 'lp_detail_page_styles6' ) {
+                  get_template_part( 'templates/listing-onepage' );
+               }
 
-		do_action( 'listing_single_page_content');
+                do_action( 'listing_single_page_content');
         get_footer();
     }
-	 

--- a/templates/listing-onepage.php
+++ b/templates/listing-onepage.php
@@ -68,7 +68,7 @@ if ( have_posts() ) {
                     break;
                 case 'lp_gallery_section':
                     if ( ! empty( $gallery ) ) {
-                        $menu_items['gallery'] = __( 'Galeri', 'listingpro' );
+                        $menu_items['gallery'] = __( 'Resim', 'listingpro' );
                     }
                     break;
                 case 'lp_video_section':

--- a/templates/listing-onepage.php
+++ b/templates/listing-onepage.php
@@ -85,6 +85,10 @@ if ( have_posts() ) {
         $youtube   = lp_onepage_meta( 'youtube' );
         $instagram = lp_onepage_meta( 'instagram' );
 
+        $locations  = get_the_terms( get_the_ID(), 'location' );
+        $categories = get_the_terms( get_the_ID(), 'listing-category' );
+        $price_html = function_exists( 'listingpro_price_dynesty' ) ? listingpro_price_dynesty( get_the_ID() ) : '';
+
         foreach ( $layout_general as $section_key ) {
             switch ( $section_key ) {
                 case 'lp_content_section':
@@ -142,6 +146,8 @@ if ( have_posts() ) {
         .lp-social-list{list-style:none;margin:20px 0 0;padding:0;display:flex;gap:10px;}
         .lp-social-list a{text-decoration:none;font-size:20px;}
         .lp-listing-tagline{margin-top:10px;font-size:18px;color:#555;}
+        .lp-home-meta{list-style:none;margin:10px 0 0;padding:0;display:flex;gap:15px;font-size:14px;color:#777;}
+        .lp-home-meta li{display:flex;align-items:center;gap:5px;}
         </style>
         <div class="lp-onepage-wrapper">
         <header class="lp-onepage-header">
@@ -164,6 +170,13 @@ if ( have_posts() ) {
             <?php $tagline = lp_onepage_meta( 'tagline_text' ); ?>
             <?php if ( ! empty( $tagline ) ) : ?>
                 <p class="lp-listing-tagline"><?php echo esc_html( $tagline ); ?></p>
+            <?php endif; ?>
+            <?php if ( ! empty( $locations ) || ! empty( $categories ) || ! empty( $price_html ) ) : ?>
+                <ul class="lp-home-meta">
+                    <?php if ( ! empty( $locations ) ) : ?><li><i class="fa fa-map-marker"></i><?php echo esc_html( $locations[0]->name ); ?></li><?php endif; ?>
+                    <?php if ( ! empty( $categories ) ) : ?><li><i class="fa fa-folder-open"></i><?php echo esc_html( $categories[0]->name ); ?></li><?php endif; ?>
+                    <?php if ( ! empty( $price_html ) ) : ?><li><?php echo $price_html; ?></li><?php endif; ?>
+                </ul>
             <?php endif; ?>
         </section>
 

--- a/templates/listing-onepage.php
+++ b/templates/listing-onepage.php
@@ -21,9 +21,38 @@ if ( have_posts() ) {
         }
 
         $menu_items = array( 'home' => __( 'Anasayfa', 'listingpro' ) );
-        $services = listingpro_get_metabox( 'lp_services' );
-        $gallery  = listingpro_get_metabox( 'lp_gallery' );
-        $video    = listingpro_get_metabox( 'lp_video_embed' );
+        $services   = listingpro_get_metabox( 'lp_services' );
+        $gallery    = listingpro_get_metabox( 'lp_gallery' );
+        $video      = listingpro_get_metabox( 'lp_video_embed' );
+
+        $plan_id = listing_get_metabox_by_ID( 'Plan_id', get_the_ID() );
+        if ( empty( $plan_id ) ) {
+            $plan_id = 'none';
+        }
+        $map_show    = get_post_meta( $plan_id, 'map_show', true );
+        $social_show = get_post_meta( $plan_id, 'listingproc_social', true );
+        $location_show = get_post_meta( $plan_id, 'listingproc_location', true );
+        $contact_show = get_post_meta( $plan_id, 'contact_show', true );
+        $website_show = get_post_meta( $plan_id, 'listingproc_website', true );
+        $hours_show   = get_post_meta( $plan_id, 'listingproc_bhours', true );
+        if ( 'none' === $plan_id ) {
+            $map_show = $social_show = $location_show = $contact_show = $website_show = $hours_show = 'true';
+        }
+
+        $address   = listingpro_get_metabox( 'gAddress' );
+        $phone     = listingpro_get_metabox( 'phone' );
+        $website   = listingpro_get_metabox( 'website' );
+        $email     = listingpro_get_metabox( 'email' );
+        $whatsapp  = listingpro_get_metabox( 'whatsapp' );
+        $latitude  = listingpro_get_metabox( 'latitude' );
+        $longitude = listingpro_get_metabox( 'longitude' );
+        $hours     = listingpro_get_metabox( 'business_hours' );
+
+        $facebook  = listingpro_get_metabox( 'facebook' );
+        $twitter   = listingpro_get_metabox( 'twitter' );
+        $linkedin  = listingpro_get_metabox( 'linkedin' );
+        $youtube   = listingpro_get_metabox( 'youtube' );
+        $instagram = listingpro_get_metabox( 'instagram' );
 
         foreach ( $layout_general as $section_key ) {
             switch ( $section_key ) {
@@ -50,6 +79,12 @@ if ( have_posts() ) {
             }
         }
 
+        if ( 'true' === $map_show && ! empty( $latitude ) && ! empty( $longitude ) ) {
+            $menu_items['map'] = __( 'Harita', 'listingpro' );
+        }
+        if ( 'true' === $hours_show && ! empty( $hours ) ) {
+            $menu_items['hours'] = __( 'Çalışma Saatleri', 'listingpro' );
+        }
         $menu_items['contact'] = __( 'İletişim', 'listingpro' );
 
         $b_logo       = $listingpro_options['business_logo_switch'];
@@ -70,6 +105,11 @@ if ( have_posts() ) {
         .lp-section-title{margin:0 0 20px;font-size:28px;font-weight:700;}
         .lp-gallery-grid{display:flex;flex-wrap:wrap;gap:15px;}
         .lp-gallery-grid img{max-width:100%;height:auto;border-radius:4px;}
+        #singlepostmap{width:100%;height:300px;border-radius:4px;}
+        .lp-contact-list{list-style:none;margin:0;padding:0;}
+        .lp-contact-list li{margin-bottom:8px;}
+        .lp-social-list{list-style:none;margin:20px 0 0;padding:0;display:flex;gap:10px;}
+        .lp-social-list a{text-decoration:none;font-size:20px;}
         </style>
         <div class="lp-onepage-wrapper">
         <header class="lp-onepage-header">
@@ -138,19 +178,50 @@ if ( have_posts() ) {
             }
         endforeach; ?>
 
+        <?php if ( isset( $menu_items['map'] ) ) :
+            $lp_map_pin = $listingpro_options['lp_map_pin']['url']; ?>
+            <section id="map" class="lp-section lp-section-map">
+                <h2 class="lp-section-title"><?php echo esc_html( $menu_items['map'] ); ?></h2>
+                <div id="singlepostmap" class="singlemap" data-lat="<?php echo esc_attr( $latitude ); ?>" data-lan="<?php echo esc_attr( $longitude ); ?>" data-pinicon="<?php echo esc_attr( $lp_map_pin ); ?>"></div>
+            </section>
+        <?php endif; ?>
+
+        <?php if ( isset( $menu_items['hours'] ) ) : ?>
+            <section id="hours" class="lp-section lp-section-hours">
+                <h2 class="lp-section-title"><?php echo esc_html( $menu_items['hours'] ); ?></h2>
+                <?php get_template_part( 'include/timings' ); ?>
+            </section>
+        <?php endif; ?>
+
         <section id="contact" class="lp-section lp-section-contact">
             <h2 class="lp-section-title"><?php echo esc_html( $menu_items['contact'] ); ?></h2>
             <ul class="lp-contact-list">
-                <?php $address = listingpro_get_metabox( 'gAddress' ); if ( $address ) : ?>
+                <?php if ( 'true' === $location_show && ! empty( $address ) ) : ?>
                     <li class="lp-contact-address"><?php echo esc_html( $address ); ?></li>
                 <?php endif; ?>
-                <?php $phone = listingpro_get_metabox( 'phone' ); if ( $phone ) : ?>
+                <?php if ( 'true' === $contact_show && ! empty( $email ) ) : ?>
+                    <li class="lp-contact-email"><a href="mailto:<?php echo esc_attr( $email ); ?>"><?php echo esc_html( $email ); ?></a></li>
+                <?php endif; ?>
+                <?php if ( 'true' === $contact_show && ! empty( $phone ) ) : ?>
                     <li class="lp-contact-phone"><?php echo esc_html( $phone ); ?></li>
                 <?php endif; ?>
-                <?php $website = listingpro_get_metabox( 'website' ); if ( $website ) : ?>
+                <?php if ( 'true' === $contact_show && ! empty( $whatsapp ) ) :
+                    $wa_link = 'https://api.whatsapp.com/send?phone=' . $whatsapp; ?>
+                    <li class="lp-contact-whatsapp"><a href="<?php echo esc_url( $wa_link ); ?>" target="_blank"><?php echo esc_html( $whatsapp ); ?></a></li>
+                <?php endif; ?>
+                <?php if ( 'true' === $website_show && ! empty( $website ) ) : ?>
                     <li class="lp-contact-website"><a href="<?php echo esc_url( $website ); ?>" target="_blank"><?php echo esc_html( $website ); ?></a></li>
                 <?php endif; ?>
             </ul>
+            <?php if ( 'true' === $social_show && ( $facebook || $twitter || $linkedin || $youtube || $instagram ) ) : ?>
+                <ul class="lp-social-list">
+                    <?php if ( ! empty( $facebook ) ) : ?><li><a href="<?php echo esc_url( $facebook ); ?>" target="_blank"><i class="fa-brands fa-square-facebook"></i></a></li><?php endif; ?>
+                    <?php if ( ! empty( $twitter ) ) : ?><li><a href="<?php echo esc_url( $twitter ); ?>" target="_blank"><i class="fa-brands fa-square-x-twitter"></i></a></li><?php endif; ?>
+                    <?php if ( ! empty( $linkedin ) ) : ?><li><a href="<?php echo esc_url( $linkedin ); ?>" target="_blank"><i class="fa-brands fa-linkedin"></i></a></li><?php endif; ?>
+                    <?php if ( ! empty( $youtube ) ) : ?><li><a href="<?php echo esc_url( $youtube ); ?>" target="_blank"><i class="fa-brands fa-youtube"></i></a></li><?php endif; ?>
+                    <?php if ( ! empty( $instagram ) ) : ?><li><a href="<?php echo esc_url( $instagram ); ?>" target="_blank"><i class="fa-brands fa-square-instagram"></i></a></li><?php endif; ?>
+                </ul>
+            <?php endif; ?>
         </section>
 
         <script>

--- a/templates/listing-onepage.php
+++ b/templates/listing-onepage.php
@@ -165,19 +165,23 @@ if ( have_posts() ) {
             </nav>
         </header>
 
+        <?php
+        $header_bg = isset( $listingpro_options['lp_detail_page_styles4_bg'] ) ? $listingpro_options['lp_detail_page_styles4_bg'] : array();
+        ?>
         <section id="home" class="lp-section lp-section-home">
-            <?php the_title('<h1 class="lp-listing-title">', '</h1>'); ?>
-            <?php $tagline = lp_onepage_meta( 'tagline_text' ); ?>
-            <?php if ( ! empty( $tagline ) ) : ?>
-                <p class="lp-listing-tagline"><?php echo esc_html( $tagline ); ?></p>
-            <?php endif; ?>
-            <?php if ( ! empty( $locations ) || ! empty( $categories ) || ! empty( $price_html ) ) : ?>
-                <ul class="lp-home-meta">
-                    <?php if ( ! empty( $locations ) ) : ?><li><i class="fa fa-map-marker"></i><?php echo esc_html( $locations[0]->name ); ?></li><?php endif; ?>
-                    <?php if ( ! empty( $categories ) ) : ?><li><i class="fa fa-folder-open"></i><?php echo esc_html( $categories[0]->name ); ?></li><?php endif; ?>
-                    <?php if ( ! empty( $price_html ) ) : ?><li><?php echo $price_html; ?></li><?php endif; ?>
-                </ul>
-            <?php endif; ?>
+            <div class="lp-listing-top-title-header" <?php if ( ! empty( $header_bg['url'] ) ) : ?>style="background-image:url(<?php echo esc_url( $header_bg['url'] ); ?>)"<?php endif; ?>>
+                <div class="lp-header-overlay"></div>
+                <div class="container pos-relative">
+                    <div class="row">
+                        <div class="col-md-8">
+                            <?php
+                            include locate_template( 'templates/single-list/listing-details-style4/content/title-bar.php' );
+                            get_template_part( 'templates/single-list/listing-details-style4/content/gallery' );
+                            ?>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </section>
 
         <?php foreach ( $layout_general as $section_key ) {

--- a/templates/listing-onepage.php
+++ b/templates/listing-onepage.php
@@ -4,22 +4,52 @@ if ( have_posts() ) {
     while ( have_posts() ) {
         the_post();
         global $listingpro_options;
+
+        $layout_keys = isset( $listingpro_options['lp-detail-page-layout6-content']['general'] )
+            ? array_keys( $listingpro_options['lp-detail-page-layout6-content']['general'] )
+            : array();
+        $layout_general = array();
+        foreach ( $layout_keys as $key ) {
+            if ( in_array( $key, array( 'lp_content_section', 'lp_video_section' ), true ) ) {
+                $layout_general[] = $key;
+            }
+        }
+        if ( ( $pos = array_search( 'lp_content_section', $layout_general, true ) ) !== false ) {
+            array_splice( $layout_general, $pos + 1, 0, array( 'lp_services_section', 'lp_gallery_section' ) );
+        } else {
+            array_splice( $layout_general, 0, 0, array( 'lp_services_section', 'lp_gallery_section' ) );
+        }
+
         $menu_items = array( 'home' => __( 'Anasayfa', 'listingpro' ) );
-        if ( listingpro_get_metabox( 'lp_listing_description' ) ) {
-            $menu_items['about'] = __( 'Hakkımızda', 'listingpro' );
-        }
         $services = listingpro_get_metabox( 'lp_services' );
-        if ( ! empty( $services ) ) {
-            $menu_items['services'] = __( 'Hizmetler', 'listingpro' );
+        $gallery  = listingpro_get_metabox( 'lp_gallery' );
+        $video    = listingpro_get_metabox( 'lp_video_embed' );
+
+        foreach ( $layout_general as $section_key ) {
+            switch ( $section_key ) {
+                case 'lp_content_section':
+                    if ( listingpro_get_metabox( 'lp_listing_description' ) ) {
+                        $menu_items['about'] = __( 'Hakkımızda', 'listingpro' );
+                    }
+                    break;
+                case 'lp_services_section':
+                    if ( ! empty( $services ) ) {
+                        $menu_items['services'] = __( 'Hizmetler', 'listingpro' );
+                    }
+                    break;
+                case 'lp_gallery_section':
+                    if ( ! empty( $gallery ) ) {
+                        $menu_items['gallery'] = __( 'Galeri', 'listingpro' );
+                    }
+                    break;
+                case 'lp_video_section':
+                    if ( ! empty( $video ) ) {
+                        $menu_items['video'] = __( 'Video', 'listingpro' );
+                    }
+                    break;
+            }
         }
-        $gallery = listingpro_get_metabox( 'lp_gallery' );
-        if ( ! empty( $gallery ) ) {
-            $menu_items['gallery'] = __( 'Galeri', 'listingpro' );
-        }
-        $video = listingpro_get_metabox( 'lp_video_embed' );
-        if ( ! empty( $video ) ) {
-            $menu_items['video'] = __( 'Video', 'listingpro' );
-        }
+
         $menu_items['contact'] = __( 'İletişim', 'listingpro' );
 
         $b_logo       = $listingpro_options['business_logo_switch'];
@@ -61,43 +91,52 @@ if ( have_posts() ) {
             <?php the_title('<h1 class="lp-listing-title">', '</h1>'); ?>
         </section>
 
-        <?php if ( isset( $menu_items['about'] ) ) : ?>
-        <section id="about" class="lp-section lp-section-about">
-            <h2 class="lp-section-title"><?php echo esc_html( $menu_items['about'] ); ?></h2>
-            <?php echo apply_filters( 'the_content', listingpro_get_metabox( 'lp_listing_description' ) ); ?>
-        </section>
-        <?php endif; ?>
-
-        <?php if ( isset( $menu_items['services'] ) ) : ?>
-        <section id="services" class="lp-section lp-section-services">
-            <h2 class="lp-section-title"><?php echo esc_html( $menu_items['services'] ); ?></h2>
-            <?php echo apply_filters( 'the_content', $services ); ?>
-        </section>
-        <?php endif; ?>
-
-        <?php if ( isset( $menu_items['gallery'] ) ) : ?>
-        <section id="gallery" class="lp-section lp-section-gallery">
-            <h2 class="lp-section-title"><?php echo esc_html( $menu_items['gallery'] ); ?></h2>
-            <div class="lp-gallery-grid">
-            <?php
-            if ( is_array( $gallery ) ) {
-                foreach ( $gallery as $image_id ) {
-                    echo wp_get_attachment_image( $image_id, 'large' );
-                }
-            } else {
-                echo apply_filters( 'the_content', $gallery );
+        <?php foreach ( $layout_general as $section_key ) :
+            switch ( $section_key ) {
+                case 'lp_content_section':
+                    if ( isset( $menu_items['about'] ) ) : ?>
+                        <section id="about" class="lp-section lp-section-about">
+                            <h2 class="lp-section-title"><?php echo esc_html( $menu_items['about'] ); ?></h2>
+                            <?php echo apply_filters( 'the_content', listingpro_get_metabox( 'lp_listing_description' ) ); ?>
+                        </section>
+                    <?php endif;
+                    break;
+                case 'lp_services_section':
+                    if ( isset( $menu_items['services'] ) ) : ?>
+                        <section id="services" class="lp-section lp-section-services">
+                            <h2 class="lp-section-title"><?php echo esc_html( $menu_items['services'] ); ?></h2>
+                            <?php echo apply_filters( 'the_content', $services ); ?>
+                        </section>
+                    <?php endif;
+                    break;
+                case 'lp_gallery_section':
+                    if ( isset( $menu_items['gallery'] ) ) : ?>
+                        <section id="gallery" class="lp-section lp-section-gallery">
+                            <h2 class="lp-section-title"><?php echo esc_html( $menu_items['gallery'] ); ?></h2>
+                            <div class="lp-gallery-grid">
+                            <?php
+                            if ( is_array( $gallery ) ) {
+                                foreach ( $gallery as $image_id ) {
+                                    echo wp_get_attachment_image( $image_id, 'large' );
+                                }
+                            } else {
+                                echo apply_filters( 'the_content', $gallery );
+                            }
+                            ?>
+                            </div>
+                        </section>
+                    <?php endif;
+                    break;
+                case 'lp_video_section':
+                    if ( isset( $menu_items['video'] ) ) : ?>
+                        <section id="video" class="lp-section lp-section-video">
+                            <h2 class="lp-section-title"><?php echo esc_html( $menu_items['video'] ); ?></h2>
+                            <?php echo apply_filters( 'the_content', $video ); ?>
+                        </section>
+                    <?php endif;
+                    break;
             }
-            ?>
-            </div>
-        </section>
-        <?php endif; ?>
-
-        <?php if ( isset( $menu_items['video'] ) ) : ?>
-        <section id="video" class="lp-section lp-section-video">
-            <h2 class="lp-section-title"><?php echo esc_html( $menu_items['video'] ); ?></h2>
-            <?php echo apply_filters( 'the_content', $video ); ?>
-        </section>
-        <?php endif; ?>
+        endforeach; ?>
 
         <section id="contact" class="lp-section lp-section-contact">
             <h2 class="lp-section-title"><?php echo esc_html( $menu_items['contact'] ); ?></h2>

--- a/templates/listing-onepage.php
+++ b/templates/listing-onepage.php
@@ -31,6 +31,17 @@ if ( have_posts() ) {
             $business_logo_url = ! empty( $business_logo ) ? $business_logo : $b_logo_default;
         }
         ?>
+        <style>
+        .lp-onepage-header{display:flex;align-items:center;justify-content:space-between;gap:30px;margin-bottom:40px;}
+        .lp-onepage-logo img{max-height:80px;width:auto;}
+        .lp-onepage-nav ul{list-style:none;margin:0;padding:0;display:flex;gap:20px;}
+        .lp-onepage-nav a{text-decoration:none;color:inherit;font-weight:600;}
+        .lp-section{margin-bottom:60px;}
+        .lp-section-title{margin:0 0 20px;font-size:28px;font-weight:700;}
+        .lp-gallery-grid{display:flex;flex-wrap:wrap;gap:15px;}
+        .lp-gallery-grid img{max-width:100%;height:auto;border-radius:4px;}
+        </style>
+        <div class="lp-onepage-wrapper">
         <header class="lp-onepage-header">
             <?php if ( ! empty( $business_logo_url ) ) : ?>
                 <div class="lp-onepage-logo"><img src="<?php echo esc_attr( $business_logo_url ); ?>" alt="<?php esc_attr_e( 'Listing Logo', 'listingpro' ); ?>"></div>
@@ -52,18 +63,22 @@ if ( have_posts() ) {
 
         <?php if ( isset( $menu_items['about'] ) ) : ?>
         <section id="about" class="lp-section lp-section-about">
+            <h2 class="lp-section-title"><?php echo esc_html( $menu_items['about'] ); ?></h2>
             <?php echo apply_filters( 'the_content', listingpro_get_metabox( 'lp_listing_description' ) ); ?>
         </section>
         <?php endif; ?>
 
         <?php if ( isset( $menu_items['services'] ) ) : ?>
         <section id="services" class="lp-section lp-section-services">
+            <h2 class="lp-section-title"><?php echo esc_html( $menu_items['services'] ); ?></h2>
             <?php echo apply_filters( 'the_content', $services ); ?>
         </section>
         <?php endif; ?>
 
         <?php if ( isset( $menu_items['gallery'] ) ) : ?>
         <section id="gallery" class="lp-section lp-section-gallery">
+            <h2 class="lp-section-title"><?php echo esc_html( $menu_items['gallery'] ); ?></h2>
+            <div class="lp-gallery-grid">
             <?php
             if ( is_array( $gallery ) ) {
                 foreach ( $gallery as $image_id ) {
@@ -73,16 +88,19 @@ if ( have_posts() ) {
                 echo apply_filters( 'the_content', $gallery );
             }
             ?>
+            </div>
         </section>
         <?php endif; ?>
 
         <?php if ( isset( $menu_items['video'] ) ) : ?>
         <section id="video" class="lp-section lp-section-video">
+            <h2 class="lp-section-title"><?php echo esc_html( $menu_items['video'] ); ?></h2>
             <?php echo apply_filters( 'the_content', $video ); ?>
         </section>
         <?php endif; ?>
 
         <section id="contact" class="lp-section lp-section-contact">
+            <h2 class="lp-section-title"><?php echo esc_html( $menu_items['contact'] ); ?></h2>
             <ul class="lp-contact-list">
                 <?php $address = listingpro_get_metabox( 'gAddress' ); if ( $address ) : ?>
                     <li class="lp-contact-address"><?php echo esc_html( $address ); ?></li>
@@ -107,6 +125,7 @@ if ( have_posts() ) {
             });
         });
         </script>
+        </div><!-- /.lp-onepage-wrapper -->
         <?php
     }
 }

--- a/templates/listing-onepage.php
+++ b/templates/listing-onepage.php
@@ -1,0 +1,113 @@
+<?php
+/* One-page listing detail template */
+if ( have_posts() ) {
+    while ( have_posts() ) {
+        the_post();
+        global $listingpro_options;
+        $menu_items = array( 'home' => __( 'Anasayfa', 'listingpro' ) );
+        if ( listingpro_get_metabox( 'lp_listing_description' ) ) {
+            $menu_items['about'] = __( 'Hakkımızda', 'listingpro' );
+        }
+        $services = listingpro_get_metabox( 'lp_services' );
+        if ( ! empty( $services ) ) {
+            $menu_items['services'] = __( 'Hizmetler', 'listingpro' );
+        }
+        $gallery = listingpro_get_metabox( 'lp_gallery' );
+        if ( ! empty( $gallery ) ) {
+            $menu_items['gallery'] = __( 'Galeri', 'listingpro' );
+        }
+        $video = listingpro_get_metabox( 'lp_video_embed' );
+        if ( ! empty( $video ) ) {
+            $menu_items['video'] = __( 'Video', 'listingpro' );
+        }
+        $menu_items['contact'] = __( 'İletişim', 'listingpro' );
+
+        $b_logo       = $listingpro_options['business_logo_switch'];
+        $allow_logo   = isset( $listingpro_options['listingpro_allow_logo_styles_switch'] ) ? $listingpro_options['listingpro_allow_logo_styles_switch'] : '';
+        $business_logo_url = '';
+        if ( $b_logo && 'yes' === $allow_logo ) {
+            $b_logo_default    = $listingpro_options['business_logo_default']['url'];
+            $business_logo     = listing_get_metabox_by_ID( 'business_logo', get_the_ID() );
+            $business_logo_url = ! empty( $business_logo ) ? $business_logo : $b_logo_default;
+        }
+        ?>
+        <header class="lp-onepage-header">
+            <?php if ( ! empty( $business_logo_url ) ) : ?>
+                <div class="lp-onepage-logo"><img src="<?php echo esc_attr( $business_logo_url ); ?>" alt="<?php esc_attr_e( 'Listing Logo', 'listingpro' ); ?>"></div>
+            <?php else : ?>
+                <div class="lp-onepage-logo"><?php the_post_thumbnail( 'medium' ); ?></div>
+            <?php endif; ?>
+            <nav class="lp-onepage-nav">
+                <ul>
+                    <?php foreach ( $menu_items as $slug => $label ) : ?>
+                        <li><a href="#<?php echo esc_attr( $slug ); ?>"><?php echo esc_html( $label ); ?></a></li>
+                    <?php endforeach; ?>
+                </ul>
+            </nav>
+        </header>
+
+        <section id="home" class="lp-section lp-section-home">
+            <?php the_title('<h1 class="lp-listing-title">', '</h1>'); ?>
+        </section>
+
+        <?php if ( isset( $menu_items['about'] ) ) : ?>
+        <section id="about" class="lp-section lp-section-about">
+            <?php echo apply_filters( 'the_content', listingpro_get_metabox( 'lp_listing_description' ) ); ?>
+        </section>
+        <?php endif; ?>
+
+        <?php if ( isset( $menu_items['services'] ) ) : ?>
+        <section id="services" class="lp-section lp-section-services">
+            <?php echo apply_filters( 'the_content', $services ); ?>
+        </section>
+        <?php endif; ?>
+
+        <?php if ( isset( $menu_items['gallery'] ) ) : ?>
+        <section id="gallery" class="lp-section lp-section-gallery">
+            <?php
+            if ( is_array( $gallery ) ) {
+                foreach ( $gallery as $image_id ) {
+                    echo wp_get_attachment_image( $image_id, 'large' );
+                }
+            } else {
+                echo apply_filters( 'the_content', $gallery );
+            }
+            ?>
+        </section>
+        <?php endif; ?>
+
+        <?php if ( isset( $menu_items['video'] ) ) : ?>
+        <section id="video" class="lp-section lp-section-video">
+            <?php echo apply_filters( 'the_content', $video ); ?>
+        </section>
+        <?php endif; ?>
+
+        <section id="contact" class="lp-section lp-section-contact">
+            <ul class="lp-contact-list">
+                <?php $address = listingpro_get_metabox( 'gAddress' ); if ( $address ) : ?>
+                    <li class="lp-contact-address"><?php echo esc_html( $address ); ?></li>
+                <?php endif; ?>
+                <?php $phone = listingpro_get_metabox( 'phone' ); if ( $phone ) : ?>
+                    <li class="lp-contact-phone"><?php echo esc_html( $phone ); ?></li>
+                <?php endif; ?>
+                <?php $website = listingpro_get_metabox( 'website' ); if ( $website ) : ?>
+                    <li class="lp-contact-website"><a href="<?php echo esc_url( $website ); ?>" target="_blank"><?php echo esc_html( $website ); ?></a></li>
+                <?php endif; ?>
+            </ul>
+        </section>
+
+        <script>
+        jQuery(function($){
+            $('.lp-onepage-nav a').on('click', function(e){
+                e.preventDefault();
+                var target = this.hash;
+                $('html, body').animate({
+                    scrollTop: $(target).offset().top
+                }, 500);
+            });
+        });
+        </script>
+        <?php
+    }
+}
+?>

--- a/templates/listing-onepage.php
+++ b/templates/listing-onepage.php
@@ -150,26 +150,31 @@ if ( have_posts() ) {
             <?php the_title('<h1 class="lp-listing-title">', '</h1>'); ?>
         </section>
 
-        <?php foreach ( $layout_general as $section_key ) :
+        <?php foreach ( $layout_general as $section_key ) {
             switch ( $section_key ) {
                 case 'lp_content_section':
-                    if ( isset( $menu_items['about'] ) ) : ?>
+                    if ( isset( $menu_items['about'] ) ) {
+                        ?>
                         <section id="about" class="lp-section lp-section-about">
                             <h2 class="lp-section-title"><?php echo esc_html( $menu_items['about'] ); ?></h2>
                             <?php echo apply_filters( 'the_content', lp_onepage_meta( 'lp_listing_description' ) ); ?>
                         </section>
-                    <?php endif;
+                        <?php
+                    }
                     break;
                 case 'lp_services_section':
-                    if ( isset( $menu_items['services'] ) ) : ?>
+                    if ( isset( $menu_items['services'] ) ) {
+                        ?>
                         <section id="services" class="lp-section lp-section-services">
                             <h2 class="lp-section-title"><?php echo esc_html( $menu_items['services'] ); ?></h2>
                             <?php echo apply_filters( 'the_content', $services ); ?>
                         </section>
-                    <?php endif;
+                        <?php
+                    }
                     break;
                 case 'lp_gallery_section':
-                    if ( isset( $menu_items['gallery'] ) ) : ?>
+                    if ( isset( $menu_items['gallery'] ) ) {
+                        ?>
                         <section id="gallery" class="lp-section lp-section-gallery">
                             <h2 class="lp-section-title"><?php echo esc_html( $menu_items['gallery'] ); ?></h2>
                             <div class="lp-gallery-grid">
@@ -184,18 +189,22 @@ if ( have_posts() ) {
                             ?>
                             </div>
                         </section>
-                    <?php endif;
+                        <?php
+                    }
                     break;
                 case 'lp_video_section':
-                    if ( isset( $menu_items['video'] ) ) : ?>
+                    if ( isset( $menu_items['video'] ) ) {
+                        ?>
                         <section id="video" class="lp-section lp-section-video">
                             <h2 class="lp-section-title"><?php echo esc_html( $menu_items['video'] ); ?></h2>
                             <?php echo apply_filters( 'the_content', $video ); ?>
                         </section>
-                    <?php endif;
+                        <?php
+                    }
                     break;
             }
-        endforeach; ?>
+        }
+        ?>
 
         <?php if ( isset( $menu_items['map'] ) ) :
             $lp_map_pin = $listingpro_options['lp_map_pin']['url']; ?>

--- a/templates/listing-onepage.php
+++ b/templates/listing-onepage.php
@@ -5,6 +5,25 @@ if ( have_posts() ) {
         the_post();
         global $listingpro_options;
 
+        if ( ! function_exists( 'lp_onepage_meta' ) ) {
+            function lp_onepage_meta( $key, $post_id = null ) {
+                $id = $post_id ? $post_id : get_the_ID();
+                if ( function_exists( 'listingpro_get_metabox' ) ) {
+                    return listingpro_get_metabox( $key );
+                }
+                return get_post_meta( $id, $key, true );
+            }
+        }
+
+        if ( ! function_exists( 'lp_onepage_meta_by_id' ) ) {
+            function lp_onepage_meta_by_id( $key, $post_id ) {
+                if ( function_exists( 'listing_get_metabox_by_ID' ) ) {
+                    return listing_get_metabox_by_ID( $key, $post_id );
+                }
+                return get_post_meta( $post_id, $key, true );
+            }
+        }
+
         $layout_keys = isset( $listingpro_options['lp-detail-page-layout6-content']['general'] )
             ? array_keys( $listingpro_options['lp-detail-page-layout6-content']['general'] )
             : array();
@@ -21,11 +40,11 @@ if ( have_posts() ) {
         }
 
         $menu_items = array( 'home' => __( 'Anasayfa', 'listingpro' ) );
-        $services   = listingpro_get_metabox( 'lp_services' );
-        $gallery    = listingpro_get_metabox( 'lp_gallery' );
-        $video      = listingpro_get_metabox( 'lp_video_embed' );
+        $services   = lp_onepage_meta( 'lp_services' );
+        $gallery    = lp_onepage_meta( 'lp_gallery' );
+        $video      = lp_onepage_meta( 'lp_video_embed' );
 
-        $plan_id = listing_get_metabox_by_ID( 'Plan_id', get_the_ID() );
+        $plan_id = lp_onepage_meta_by_id( 'Plan_id', get_the_ID() );
         if ( empty( $plan_id ) ) {
             $plan_id = 'none';
         }
@@ -39,25 +58,25 @@ if ( have_posts() ) {
             $map_show = $social_show = $location_show = $contact_show = $website_show = $hours_show = 'true';
         }
 
-        $address   = listingpro_get_metabox( 'gAddress' );
-        $phone     = listingpro_get_metabox( 'phone' );
-        $website   = listingpro_get_metabox( 'website' );
-        $email     = listingpro_get_metabox( 'email' );
-        $whatsapp  = listingpro_get_metabox( 'whatsapp' );
-        $latitude  = listingpro_get_metabox( 'latitude' );
-        $longitude = listingpro_get_metabox( 'longitude' );
-        $hours     = listingpro_get_metabox( 'business_hours' );
+        $address   = lp_onepage_meta( 'gAddress' );
+        $phone     = lp_onepage_meta( 'phone' );
+        $website   = lp_onepage_meta( 'website' );
+        $email     = lp_onepage_meta( 'email' );
+        $whatsapp  = lp_onepage_meta( 'whatsapp' );
+        $latitude  = lp_onepage_meta( 'latitude' );
+        $longitude = lp_onepage_meta( 'longitude' );
+        $hours     = lp_onepage_meta( 'business_hours' );
 
-        $facebook  = listingpro_get_metabox( 'facebook' );
-        $twitter   = listingpro_get_metabox( 'twitter' );
-        $linkedin  = listingpro_get_metabox( 'linkedin' );
-        $youtube   = listingpro_get_metabox( 'youtube' );
-        $instagram = listingpro_get_metabox( 'instagram' );
+        $facebook  = lp_onepage_meta( 'facebook' );
+        $twitter   = lp_onepage_meta( 'twitter' );
+        $linkedin  = lp_onepage_meta( 'linkedin' );
+        $youtube   = lp_onepage_meta( 'youtube' );
+        $instagram = lp_onepage_meta( 'instagram' );
 
         foreach ( $layout_general as $section_key ) {
             switch ( $section_key ) {
                 case 'lp_content_section':
-                    if ( listingpro_get_metabox( 'lp_listing_description' ) ) {
+                    if ( lp_onepage_meta( 'lp_listing_description' ) ) {
                         $menu_items['about'] = __( 'Hakkımızda', 'listingpro' );
                     }
                     break;
@@ -92,7 +111,7 @@ if ( have_posts() ) {
         $business_logo_url = '';
         if ( $b_logo && 'yes' === $allow_logo ) {
             $b_logo_default    = $listingpro_options['business_logo_default']['url'];
-            $business_logo     = listing_get_metabox_by_ID( 'business_logo', get_the_ID() );
+            $business_logo     = lp_onepage_meta_by_id( 'business_logo', get_the_ID() );
             $business_logo_url = ! empty( $business_logo ) ? $business_logo : $b_logo_default;
         }
         ?>
@@ -137,7 +156,7 @@ if ( have_posts() ) {
                     if ( isset( $menu_items['about'] ) ) : ?>
                         <section id="about" class="lp-section lp-section-about">
                             <h2 class="lp-section-title"><?php echo esc_html( $menu_items['about'] ); ?></h2>
-                            <?php echo apply_filters( 'the_content', listingpro_get_metabox( 'lp_listing_description' ) ); ?>
+                            <?php echo apply_filters( 'the_content', lp_onepage_meta( 'lp_listing_description' ) ); ?>
                         </section>
                     <?php endif;
                     break;


### PR DESCRIPTION
## Summary
- map one-page listing template to selectable style 6 while keeping existing style 5
- load one-page layout when style 6 is chosen on the single listing page
- render gallery images individually in one-page template to avoid fatal error

## Testing
- `php -l templates/listing-onepage.php`
- `php -l single-listing.php`
- `php -l include/options-config.php`
- `python -m json.tool include/setup/content/classic-x/themeOptions.json | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_68bebfb2d4648323931113930ca41bfd