### PR TITLE
feat: add one-page listing template

### DIFF
--- a/include/options-config.php
+++ b/include/options-config.php
@@ -2181,14 +2181,14 @@ Redux::setSection($opt_name, array(
             'id' => 'lp_detail_page_styles',
             'type' => 'select',
             'title' => __('Select listing detail page Style', 'listingpro'),
-            'desc' => __('Choose from 1 of 4 styles.', 'listingpro'),
+            'desc' => __('Choose from the available styles.', 'listingpro'),
             'options' => array(
                 'lp_detail_page_styles1' => 'Listing Detail Page Style 1',
                 'lp_detail_page_styles2' => 'Listing Detail Page Style 2',
                 'lp_detail_page_styles3' => 'Listing Detail Page Style 3',
                 'lp_detail_page_styles4' => 'Listing Detail Page Style 4',
-				'lp_detail_page_styles6' => 'Listing Detail Page Style 5' //classic new style
-                /* 'lp_detail_page_styles5' => 'Listing Detail Page Style 5', */
+                'lp_detail_page_styles5' => 'Listing Detail Page Style 5',
+                'lp_detail_page_styles6' => 'Listing Detail Page Style 6 (One Page)',
             ),
             'default' => 'lp_detail_page_styles1',
         ),
@@ -2208,6 +2208,60 @@ Redux::setSection($opt_name, array(
                     'lp_services_section' => 'Services',
                     'lp_reviews_section' => 'Reviews',
                     'lp_quote_section' => 'Quote Form',
+                ),
+                'disabled' => array(
+                    '' => '',
+                ),
+            ),
+        ),
+        array(
+            'id' => 'lp-detail-page-layout6-content',
+            'type' => 'sorter',
+            'title' => 'Content Layout',
+            'required' => array('lp_detail_page_styles', 'equals', 'lp_detail_page_styles6'),
+            'desc' => 'Shuffle elements within Listing Detail Content',
+            'compiler' => 'true',
+            'options' => array(
+                'general' => array(
+                    'lp_video_section' => 'Video',
+                    'lp_content_section' => 'Details',
+                    'lp_services_section' => 'Services',
+                    'lp_gallery_section' => 'Resim',
+                    // New update 2.8                    // 'lp_openFields_section' => 'Listing Global Form Fields',
+                    // End New update 2.8
+                    'lp_features_section' => 'Listing Features',
+                    'lp_additional_section' => 'Additional Details',
+                    'lp_faqs_section' => 'FAQs',
+                    'lp_event_section' => 'Event',
+                    'lp_announcements_section' => 'Announcements',
+                    'lp_offers_section' => 'Offers/Discounts/Deals',
+                    'lp_menu_section' => 'Menu',
+                    'lp_reviews_section' => 'Reviews',
+                    'lp_reviewform_section' => 'Review Form',
+                ),
+                'disabled' => array(
+                    '' => '',
+                ),
+            ),
+        ),
+        array(
+            'id' => 'lp-detail-page-layout6-rsidebar',
+            'type' => 'sorter',
+            'title' => 'Sidebar Layout',
+            'required' => array('lp_detail_page_styles', 'equals', 'lp_detail_page_styles6'),
+            'desc' => 'Shuffle elements within Listing SideBar',
+            'compiler' => 'true',
+            'options' => array(
+                'sidebar' => array(
+                    'lp_mapsocial_section' => 'Map/Contacts',
+                    'lp_event_section' => 'Event',
+                    'lp_booking_section' => 'Appointments',
+                    'lp_timing_section' => 'Timings',
+                    'lp_quicks_section' => 'Quick Actions',
+                    'lp_additional_section' => 'Additional Details',
+                    'lp_offers_section' => 'Offers/Discounts/Deals',
+                    'lp_leadform_section' => 'Leadform',
+                    'lp_sidebarelemnts_section' => 'Detail Page Sidebar Widgets',
                 ),
                 'disabled' => array(
                     '' => '',
@@ -2436,59 +2490,6 @@ Redux::setSection($opt_name, array(
                 ),
             ),
         ),
-		//classic new style
-		array(
-            'id' => 'lp-detail-page-layout6-content',
-            'type' => 'sorter',
-            'title' => 'Content Layout',
-            'required' => array('lp_detail_page_styles', 'equals', 'lp_detail_page_styles6'),
-            'desc' => 'Shuffle elements within Listing Detail Content',
-            'compiler' => 'true',
-            'options' => array(
-                'general' => array(
-                    'lp_video_section' => 'Youtube Video',
-                    'lp_content_section' => 'Details',
-                    // New update 2.8                    // 'lp_openFields_section' => 'Listing Global Form Fields',
-                    // End New update 2.8
-                    'lp_features_section' => 'Listing Features',
-                    'lp_additional_section' => 'Additional Details',
-                    'lp_faqs_section' => 'FAQs',
-                    'lp_event_section' => 'Event',
-                    'lp_announcements_section' => 'Announcements',
-                    'lp_offers_section' => 'Offers/Discounts/Deals',
-                    'lp_menu_section' => 'Menu',
-                    'lp_reviews_section' => 'Reviews',
-                    'lp_reviewform_section' => 'Review Form',
-                ),
-                'disabled' => array(
-                    '' => '',
-                ),
-            ),
-        ),
-        array(
-            'id' => 'lp-detail-page-layout6-rsidebar',
-            'type' => 'sorter',
-            'title' => 'Sidebar Layout',
-            'required' => array('lp_detail_page_styles', 'equals', 'lp_detail_page_styles6'),
-            'desc' => 'Shuffle elements within Listing SideBar',
-            'compiler' => 'true',
-            'options' => array(
-                'sidebar' => array(
-                    'lp_mapsocial_section' => 'Map/Contacts',
-                    'lp_event_section' => 'Event',
-                    'lp_booking_section' => 'Appointments',
-                    'lp_timing_section' => 'Timings',
-                    'lp_quicks_section' => 'Quick Actions',
-                    'lp_additional_section' => 'Additional Details',
-                    'lp_offers_section' => 'Offers/Discounts/Deals',
-                    'lp_leadform_section' => 'Leadform',
-                    'lp_sidebarelemnts_section' => 'Detail Page Sidebar Widgets',
-                ),
-                'disabled' => array(
-                    '' => '',
-                ),
-            ),
-        ),
         array(
             'id' => 'lp_detail_page_additional_styles',
             'type' => 'button_set',
@@ -2505,7 +2506,7 @@ Redux::setSection($opt_name, array(
             'id' => 'lp_detail_page_video_display',
             'type' => 'button_set',
             'title' => esc_html__('Video Display Option', 'listingpro'),
-            'required' => array('lp_detail_page_styles', 'equals', array('lp_detail_page_styles6', 'lp_detail_page_styles1')), //classic new style
+            'required' => array('lp_detail_page_styles', 'equals', array('lp_detail_page_styles5', 'lp_detail_page_styles1')), //classic new style
             'subtitle' => esc_html__('On=Show youtube video in popup, off=embed', 'listingpro'),
             'options' => array(
                 'on' => 'On',
@@ -2549,7 +2550,7 @@ Redux::setSection($opt_name, array(
             'title' => esc_html__('Discount/Deals (sidebar)', 'listingpro'),
             'subtitle' => esc_html__('design for sidebar area', 'listingpro'),
             'desc' => esc_html__('The design used when deals show within the sidebar.', 'listingpro'),
-            'required' => array('lp_detail_page_styles', 'equals', array('lp_detail_page_styles4', 'lp_detail_page_styles3', 'lp_detail_page_styles2', 'lp_detail_page_styles1' , 'lp_detail_page_styles6')), //classic new style
+            'required' => array('lp_detail_page_styles', 'equals', array('lp_detail_page_styles4', 'lp_detail_page_styles3', 'lp_detail_page_styles2', 'lp_detail_page_styles1' , 'lp_detail_page_styles5')), //classic new style
             'options' => array(
                 '1' => array(
                     'alt' => 'Deals Design',

--- a/include/options-config.php
+++ b/include/options-config.php
@@ -2236,6 +2236,8 @@ Redux::setSection($opt_name, array(
                     'lp_announcements_section' => 'Announcements',
                     'lp_offers_section' => 'Offers/Discounts/Deals',
                     'lp_menu_section' => 'Menu',
+                    'lp_booking_section' => 'Appointments',
+                    'lp_quicks_section' => 'Quick Actions',
                     'lp_reviews_section' => 'Reviews',
                     'lp_reviewform_section' => 'Review Form',
                 ),

--- a/include/options-config.php
+++ b/include/options-config.php
@@ -2214,62 +2214,6 @@ Redux::setSection($opt_name, array(
                 ),
             ),
         ),
-        array(
-            'id' => 'lp-detail-page-layout6-content',
-            'type' => 'sorter',
-            'title' => 'Content Layout',
-            'required' => array('lp_detail_page_styles', 'equals', 'lp_detail_page_styles6'),
-            'desc' => 'Shuffle elements within Listing Detail Content',
-            'compiler' => 'true',
-            'options' => array(
-                'general' => array(
-                    'lp_video_section' => 'Video',
-                    'lp_content_section' => 'Details',
-                    'lp_services_section' => 'Services',
-                    'lp_gallery_section' => 'Resim',
-                    // New update 2.8                    // 'lp_openFields_section' => 'Listing Global Form Fields',
-                    // End New update 2.8
-                    'lp_features_section' => 'Listing Features',
-                    'lp_additional_section' => 'Additional Details',
-                    'lp_faqs_section' => 'FAQs',
-                    'lp_event_section' => 'Event',
-                    'lp_announcements_section' => 'Announcements',
-                    'lp_offers_section' => 'Offers/Discounts/Deals',
-                    'lp_menu_section' => 'Menu',
-                    'lp_booking_section' => 'Appointments',
-                    'lp_quicks_section' => 'Quick Actions',
-                    'lp_reviews_section' => 'Reviews',
-                    'lp_reviewform_section' => 'Review Form',
-                ),
-                'disabled' => array(
-                    '' => '',
-                ),
-            ),
-        ),
-        array(
-            'id' => 'lp-detail-page-layout6-rsidebar',
-            'type' => 'sorter',
-            'title' => 'Sidebar Layout',
-            'required' => array('lp_detail_page_styles', 'equals', 'lp_detail_page_styles6'),
-            'desc' => 'Shuffle elements within Listing SideBar',
-            'compiler' => 'true',
-            'options' => array(
-                'sidebar' => array(
-                    'lp_mapsocial_section' => 'Map/Contacts',
-                    'lp_event_section' => 'Event',
-                    'lp_booking_section' => 'Appointments',
-                    'lp_timing_section' => 'Timings',
-                    'lp_quicks_section' => 'Quick Actions',
-                    'lp_additional_section' => 'Additional Details',
-                    'lp_offers_section' => 'Offers/Discounts/Deals',
-                    'lp_leadform_section' => 'Leadform',
-                    'lp_sidebarelemnts_section' => 'Detail Page Sidebar Widgets',
-                ),
-                'disabled' => array(
-                    '' => '',
-                ),
-            ),
-        ),
         /* for listing layout3 & 4 */
         array(
             'id' => 'lp-detail-page-layout4-content',

--- a/include/reviews/reviews-form.php
+++ b/include/reviews/reviews-form.php
@@ -1,4 +1,67 @@
 <?php
+if (!function_exists('lp_prepare_multi_rating_fields')) {
+    function lp_prepare_multi_rating_fields($raw_fields)
+    {
+        $prepared = [];
+
+        if (!is_array($raw_fields) || empty($raw_fields)) {
+            return $prepared;
+        }
+
+        if (isset($raw_fields['default']) && is_array($raw_fields['default'])) {
+            foreach ($raw_fields['default'] as $index => $label) {
+                if (!is_string($label)) {
+                    continue;
+                }
+
+                $label = trim(wp_strip_all_tags($label));
+
+                if ($label === '') {
+                    continue;
+                }
+
+                $prepared[$index] = $label;
+            }
+
+            return $prepared;
+        }
+
+        foreach ($raw_fields as $index => $label) {
+            if (is_array($label)) {
+                foreach ($label as $nested_index => $nested_label) {
+                    if (!is_string($nested_label)) {
+                        continue;
+                    }
+
+                    $nested_label = trim(wp_strip_all_tags($nested_label));
+
+                    if ($nested_label === '') {
+                        continue;
+                    }
+
+                    $prepared[$nested_index] = $nested_label;
+                }
+
+                continue;
+            }
+
+            if (!is_string($label)) {
+                continue;
+            }
+
+            $label = trim(wp_strip_all_tags($label));
+
+            if ($label === '') {
+                continue;
+            }
+
+            $prepared[$index] = $label;
+        }
+
+        return $prepared;
+    }
+}
+
 if (!function_exists('listingpro_get_reviews_form')) {
     function listingpro_get_reviews_form($postid)
     {
@@ -31,8 +94,14 @@ if (!function_exists('listingpro_get_reviews_form')) {
             $enableUsernameField = lp_theme_option('lp_register_username');
 
             $lp_multi_rating_state        =   $listingpro_options['lp_multirating_switch'];
+            $lp_multi_rating_fields       =   [];
+
             if ($lp_multi_rating_state == 1 && !empty($lp_multi_rating_state)) {
-                $lp_multi_rating_fields =   get_listing_multi_ratings_fields($postid);
+                $lp_multi_rating_fields = lp_prepare_multi_rating_fields(get_listing_multi_ratings_fields($postid));
+
+                if (empty($lp_multi_rating_fields)) {
+                    $lp_multi_rating_state = 0;
+                }
             }
 
             $lp_detail_page_styles  =   $listingpro_options['lp_detail_page_styles'];
@@ -51,30 +120,19 @@ if (!function_exists('listingpro_get_reviews_form')) {
                     <?php } ?>
                     <form data-lp-recaptcha="<?php echo wp_kses_post($enableCaptcha); ?>" data-lp-recaptcha-sitekey="<?php echo wp_kses_post($gSiteKey); ?>" data-multi-rating="<?php echo esc_attr($lp_multi_rating_state); ?>" id="rewies_form" name="rewies_form" action="" method="post" enctype="multipart/form-data" data-imgcount="<?php echo esc_attr($lp_images_count); ?>" data-imgsize="<?php echo esc_attr($lp_images_size); ?>" data-countnotice="<?php echo esc_attr($lp_imagecount_notice); ?>" data-sizenotice="<?php echo esc_attr($lp_imagesize_notice); ?>">
                         <?php
-                        if ($lp_multi_rating_state == 1 && is_array($lp_multi_rating_fields) && !empty($lp_multi_rating_fields)) {
+                        if ($lp_multi_rating_state == 1 && !empty($lp_multi_rating_fields)) {
                             echo '<div class="col-md-12 padding-left-0 lp-multi-rating-ui-wrap">';
-                            $lp_rating_field_counter    =    1;
-                            //New update 2.6.10
-                            $switch  = get_option('lp_multirating_switch');
-                            if ($switch == 1 && !empty($switch)) {
-                                $multi_rating_fileds = $lp_multi_rating_fields;
-                            } else {
-                                $multi_rating_fileds = $lp_multi_rating_fields['default'];
-                            }
-                            foreach ($multi_rating_fileds as $k => $lp_multi_rating_field) {
-                                //End New update 2.6.10
+                            foreach ($lp_multi_rating_fields as $k => $lp_multi_rating_field) {
                         ?>
                                 <div class="<?php echo esc_attr($multi_col_class); ?> padding-left-0">
                                     <div class="list-style-none form-review-stars">
-                                        <p><?php echo esc_attr($lp_multi_rating_field); ?></p>
+                                        <p><?php echo esc_html($lp_multi_rating_field); ?></p>
                                         <input type="hidden" data-mrf="<?php echo esc_attr($k); ?>" id="review-rating-<?php echo esc_attr($k); ?>" name="rating-<?php echo esc_attr($k); ?>" class="rating-tooltip lp-multi-rating-val" data-filled="fa fa-star fa-2x" data-empty="fa-regular fa-star-o fa-2x" />
 
                                     </div>
                                 </div>
 
-                            <?php
-                                $lp_rating_field_counter++;
-                            }
+                            <?php }
                             echo '<div class="clearfix"></div>';
                             ?>
                             <div class="col-md-6 padding-left-0">
@@ -189,31 +247,20 @@ if (!function_exists('listingpro_get_reviews_form')) {
                         <?php } ?>
 
                         <?php
-                        if ($lp_multi_rating_state == 1 && is_array($lp_multi_rating_fields) && !empty($lp_multi_rating_fields)) {
+                        if ($lp_multi_rating_state == 1 && !empty($lp_multi_rating_fields)) {
                             echo '<div class="col-md-12 padding-left-0 lp-multi-rating-ui-wrap">';
-                            $lp_rating_field_counter    =    1;
-                            //New update 2.6.10
-                            $switch  = get_option('lp_multirating_switch');
-                            if ($switch == 1 && !empty($switch)) {
-                                $multi_rating_fileds = $lp_multi_rating_fields;
-                            } else {
-                                $multi_rating_fileds = $lp_multi_rating_fields['default'];
-                            }
-                            //End New update 2.6.10
 
-                            foreach ($multi_rating_fileds as $k => $lp_multi_rating_field) {
+                            foreach ($lp_multi_rating_fields as $k => $lp_multi_rating_field) {
                         ?>
                                 <div class="<?php echo esc_attr($multi_col_class); ?> padding-left-0">
                                     <div class="sfdfdf list-style-none form-review-stars">
-                                        <p><?php echo esc_attr($lp_multi_rating_field); ?></p>
+                                        <p><?php echo esc_html($lp_multi_rating_field); ?></p>
                                         <input type="hidden" data-mrf="<?php echo esc_attr($k); ?>" id="review-rating-<?php echo esc_attr($k); ?>" name="rating-<?php echo esc_attr($k); ?>" class="rating-tooltip lp-multi-rating-val" data-filled="fa fa-star fa-2x" data-empty="fa-regular fa-star-o fa-2x" />
 
                                     </div>
                                 </div>
 
-                            <?php
-                                $lp_rating_field_counter++;
-                            }
+                            <?php }
                             echo '<div class="clearfix"></div>';
                             ?>
                             <div class="col-md-6 padding-left-0">
@@ -399,9 +446,14 @@ if (!function_exists('listingpro_get_reviews_form_v2')) {
             $enableUsernameField = lp_theme_option('lp_register_username');
 
             $lp_multi_rating_state        =   $listingpro_options['lp_multirating_switch'];
+            $lp_multi_rating_fields       =   [];
 
             if ($lp_multi_rating_state == 1 && !empty($lp_multi_rating_state)) {
-                $lp_multi_rating_fields =   get_listing_multi_ratings_fields($postid);
+                $lp_multi_rating_fields = lp_prepare_multi_rating_fields(get_listing_multi_ratings_fields($postid));
+
+                if (empty($lp_multi_rating_fields)) {
+                    $lp_multi_rating_state = 0;
+                }
             }
 
             $multi_left_col =   '';
@@ -410,7 +462,7 @@ if (!function_exists('listingpro_get_reviews_form_v2')) {
 
 
 
-            if ($lp_multi_rating_state == 1 && is_array($lp_multi_rating_fields) && !empty($lp_multi_rating_fields)) {
+            if ($lp_multi_rating_state == 1 && !empty($lp_multi_rating_fields)) {
 
                 $multi_left_col =   'lp-review-form-top-multi';
 
@@ -435,7 +487,7 @@ if (!function_exists('listingpro_get_reviews_form_v2')) {
 
                     <?php
 
-                    if ($lp_multi_rating_state == 1 && is_array($lp_multi_rating_fields) && !empty($lp_multi_rating_fields)) {
+                    if ($lp_multi_rating_state == 1 && !empty($lp_multi_rating_fields)) {
 
                     ?>
 
@@ -513,23 +565,13 @@ if (!function_exists('listingpro_get_reviews_form_v2')) {
 
                     <?php
 
-                    if ($lp_multi_rating_state == 1 && is_array($lp_multi_rating_fields) && !empty($lp_multi_rating_fields)) {
+            if ($lp_multi_rating_state == 1 && !empty($lp_multi_rating_fields)) {
 
                         echo '<div class="form-group">';
 
                         echo '<div class="col-md-12 padding-left-0 lp-multi-rating-ui-wrap">';
 
-                        $lp_rating_field_counter    =    1;
-                        //New update 2.6.10
-                        $switch  = get_option('lp_multirating_switch');
-                        if ($switch == 1 && !empty($switch)) {
-                            $multi_rating_fileds = $lp_multi_rating_fields;
-                        } else {
-                            $multi_rating_fileds = $lp_multi_rating_fields['default'];
-                        }
-                        //End New update 2.6.10
-
-                        foreach ($multi_rating_fileds as $k => $lp_multi_rating_field) {
+                        foreach ($lp_multi_rating_fields as $k => $lp_multi_rating_field) {
 
                     ?>
 
@@ -537,7 +579,7 @@ if (!function_exists('listingpro_get_reviews_form_v2')) {
 
                                 <div class="sfdfdf list-style-none form-review-stars">
 
-                                    <p><?php echo esc_attr($lp_multi_rating_field); ?></p>
+                                    <p><?php echo esc_html($lp_multi_rating_field); ?></p>
 
                                     <input type="hidden" data-mrf="<?php echo esc_attr($k); ?>" id="review-rating-<?php echo esc_attr($k); ?>" name="rating-<?php echo esc_attr($k); ?>" class="rating-tooltip lp-multi-rating-val" data-filled="fa fa-star fa-2x" data-empty="fa-regular fa-star-o fa-2x" />
 
@@ -549,7 +591,6 @@ if (!function_exists('listingpro_get_reviews_form_v2')) {
 
                     <?php
 
-                            $lp_rating_field_counter++;
                         }
 
                         echo '<div class="clearfix"></div>';
@@ -677,7 +718,7 @@ if (!function_exists('listingpro_get_reviews_form_v2')) {
 
                             <?php
 
-                            if ($lp_multi_rating_state == 1 && is_array($lp_multi_rating_fields) && !empty($lp_multi_rating_fields)) {
+                            if ($lp_multi_rating_state == 1 && !empty($lp_multi_rating_fields)) {
 
                             ?>
 
@@ -749,11 +790,9 @@ if (!function_exists('listingpro_get_reviews_form_v2')) {
 
                             <?php
 
-                            if ($lp_multi_rating_state == 1 && is_array($lp_multi_rating_fields) && !empty($lp_multi_rating_fields)) {
+                            if ($lp_multi_rating_state == 1 && !empty($lp_multi_rating_fields)) {
 
                                 echo '<div class="col-md-12 padding-left-0 lp-multi-rating-ui-wrap">';
-
-                                $lp_rating_field_counter    =    1;
 
                                 foreach ($lp_multi_rating_fields as $k => $lp_multi_rating_field) {
 
@@ -763,7 +802,7 @@ if (!function_exists('listingpro_get_reviews_form_v2')) {
 
                                         <div class="sfdfdf list-style-none form-review-stars">
 
-                                            <p><?php echo esc_attr($lp_multi_rating_field); ?></p>
+                                            <p><?php echo esc_html($lp_multi_rating_field); ?></p>
 
                                             <input type="hidden" data-mrf="<?php echo esc_attr($k); ?>" id="review-rating-<?php echo esc_attr($k); ?>" name="rating-<?php echo esc_attr($k); ?>" class="rating-tooltip lp-multi-rating-val" data-filled="fa fa-star fa-2x" data-empty="fa-regular fa-star-o fa-2x" />
 
@@ -771,10 +810,7 @@ if (!function_exists('listingpro_get_reviews_form_v2')) {
 
                                     </div>
 
-                            <?php
-
-                                    $lp_rating_field_counter++;
-                                }
+                            <?php }
 
                                 echo '<div class="clearfix"></div>';
 

--- a/include/setup/content/classic-x/themeOptions.json
+++ b/include/setup/content/classic-x/themeOptions.json
@@ -323,7 +323,7 @@
         "width": "",
         "thumbnail": ""
     },
-    "lp_detail_page_styles": "lp_detail_page_styles6",
+    "lp_detail_page_styles": "lp_detail_page_styles5",
     "lp-detail-page-layout5-content": {
         "general": {
             "placebo": "placebo",
@@ -334,6 +334,46 @@
             "lp_services_section": "Services",
             "lp_reviews_section": "Reviews",
             "lp_quote_section": "Quote Form"
+        },
+        "disabled": {
+            "placebo": "placebo",
+            "0": ""
+        }
+    },
+    "lp-detail-page-layout6-content": {
+        "general": {
+            "placebo": "placebo",
+            "lp_video_section": "Video",
+            "lp_content_section": "Details",
+            "lp_services_section": "Services",
+            "lp_gallery_section": "Resim",
+            "lp_features_section": "Listing Features",
+            "lp_additional_section": "Additional Details",
+            "lp_faqs_section": "FAQs",
+            "lp_event_section": "Event",
+            "lp_announcements_section": "Announcements",
+            "lp_offers_section": "Offers\/Discounts\/Deals",
+            "lp_menu_section": "Menu",
+            "lp_reviews_section": "Reviews",
+            "lp_reviewform_section": "Review Form"
+        },
+        "disabled": {
+            "placebo": "placebo",
+            "0": ""
+        }
+    },
+    "lp-detail-page-layout6-rsidebar": {
+        "sidebar": {
+            "placebo": "placebo",
+            "lp_mapsocial_section": "Map\/Contacts",
+            "lp_event_section": "Event",
+            "lp_booking_section": "Appointments",
+            "lp_timing_section": "Timings",
+            "lp_quicks_section": "Quick Actions",
+            "lp_additional_section": "Additional Details",
+            "lp_offers_section": "Offers\/Discounts\/Deals",
+            "lp_leadform_section": "Leadform",
+            "lp_sidebarelemnts_section": "Detail Page Sidebar Widgets"
         },
         "disabled": {
             "placebo": "placebo",
@@ -495,44 +535,6 @@
             "lp_event_section": "Event",
             "lp_offers_section": "Offers\/Discounts\/Deals",
             "lp_booking_section": "Appointments"
-        }
-    },
-    "lp-detail-page-layout6-content": {
-        "general": {
-            "placebo": "placebo",
-            "lp_video_section": "Youtube Video",
-            "lp_content_section": "Details",
-            "lp_features_section": "Listing Features",
-            "lp_additional_section": "Additional Details",
-            "lp_faqs_section": "FAQs",
-            "lp_reviews_section": "Reviews",
-            "lp_announcements_section": "Announcements",
-            "lp_reviewform_section": "Review Form",
-            "lp_event_section": "Event",
-            "lp_menu_section": "Menu",
-            "lp_offers_section": "Offers\/Discounts\/Deals"
-        },
-        "disabled": {
-            "placebo": "placebo",
-            "0": ""
-        }
-    },
-    "lp-detail-page-layout6-rsidebar": {
-        "sidebar": {
-            "placebo": "placebo",
-            "lp_timing_section": "Timings",
-            "lp_mapsocial_section": "Map\/Contacts",
-            "lp_additional_section": "Additional Details",
-            "lp_leadform_section": "Leadform",
-            "lp_booking_section": "Appointments",
-            "lp_quicks_section": "Quick Actions",
-            "lp_offers_section": "Offers\/Discounts\/Deals",
-            "lp_event_section": "Event",
-            "lp_sidebarelemnts_section": "Detail Page Sidebar Widgets"
-        },
-        "disabled": {
-            "placebo": "placebo",
-            "0": ""
         }
     },
     "lp_detail_page_additional_styles": "right",

--- a/include/setup/content/classic-x/themeOptions.json
+++ b/include/setup/content/classic-x/themeOptions.json
@@ -354,6 +354,8 @@
             "lp_announcements_section": "Announcements",
             "lp_offers_section": "Offers\/Discounts\/Deals",
             "lp_menu_section": "Menu",
+            "lp_booking_section": "Appointments",
+            "lp_quicks_section": "Quick Actions",
             "lp_reviews_section": "Reviews",
             "lp_reviewform_section": "Review Form"
         },

--- a/include/setup/content/classic-x/themeOptions.json
+++ b/include/setup/content/classic-x/themeOptions.json
@@ -340,48 +340,6 @@
             "0": ""
         }
     },
-    "lp-detail-page-layout6-content": {
-        "general": {
-            "placebo": "placebo",
-            "lp_video_section": "Video",
-            "lp_content_section": "Details",
-            "lp_services_section": "Services",
-            "lp_gallery_section": "Resim",
-            "lp_features_section": "Listing Features",
-            "lp_additional_section": "Additional Details",
-            "lp_faqs_section": "FAQs",
-            "lp_event_section": "Event",
-            "lp_announcements_section": "Announcements",
-            "lp_offers_section": "Offers\/Discounts\/Deals",
-            "lp_menu_section": "Menu",
-            "lp_booking_section": "Appointments",
-            "lp_quicks_section": "Quick Actions",
-            "lp_reviews_section": "Reviews",
-            "lp_reviewform_section": "Review Form"
-        },
-        "disabled": {
-            "placebo": "placebo",
-            "0": ""
-        }
-    },
-    "lp-detail-page-layout6-rsidebar": {
-        "sidebar": {
-            "placebo": "placebo",
-            "lp_mapsocial_section": "Map\/Contacts",
-            "lp_event_section": "Event",
-            "lp_booking_section": "Appointments",
-            "lp_timing_section": "Timings",
-            "lp_quicks_section": "Quick Actions",
-            "lp_additional_section": "Additional Details",
-            "lp_offers_section": "Offers\/Discounts\/Deals",
-            "lp_leadform_section": "Leadform",
-            "lp_sidebarelemnts_section": "Detail Page Sidebar Widgets"
-        },
-        "disabled": {
-            "placebo": "placebo",
-            "0": ""
-        }
-    },
     "lp-detail-page-layout4-content": {
         "general": {
             "placebo": "placebo",

--- a/single-listing.php
+++ b/single-listing.php
@@ -52,14 +52,13 @@
 		{
 			get_template_part( 'templates/listing-style4' );
 		}
-		else if( $lp_detail_page_styles == 'lp_detail_page_styles5' )
-		{
-			get_template_part( 'templates/listing_detail5' );
-		}else if( $lp_detail_page_styles == 'lp_detail_page_styles6' ) {
-		   get_template_part( 'templates/listing-detail6' ); //classic new style
-		}
+               else if( $lp_detail_page_styles == 'lp_detail_page_styles5' ) {
+                  get_template_part( 'templates/listing_detail5' );
+               }
+               else if( $lp_detail_page_styles == 'lp_detail_page_styles6' ) {
+                  get_template_part( 'templates/listing-onepage' );
+               }
 
-		do_action( 'listing_single_page_content');
+                do_action( 'listing_single_page_content');
         get_footer();
     }
-	 

--- a/templates/listing-onepage.php
+++ b/templates/listing-onepage.php
@@ -75,6 +75,10 @@ if ( have_posts() ) {
         $website   = lp_onepage_meta( 'website' );
         $email     = lp_onepage_meta( 'email' );
         $whatsapp  = lp_onepage_meta( 'whatsapp' );
+        $wa_link   = '';
+        if ( ! empty( $whatsapp ) ) {
+            $wa_link = 'https://api.whatsapp.com/send?phone=' . preg_replace( '/\D+/', '', $whatsapp );
+        }
         $latitude  = lp_onepage_meta( 'latitude' );
         $longitude = lp_onepage_meta( 'longitude' );
         $hours     = lp_onepage_meta( 'business_hours' );
@@ -211,6 +215,7 @@ if ( have_posts() ) {
         .lp-listing-tagline{margin-top:10px;font-size:18px;color:#555;}
         .lp-home-meta{list-style:none;margin:10px 0 0;padding:0;display:flex;gap:15px;font-size:14px;color:#777;justify-content:center;}
         .lp-home-meta li{display:flex;align-items:center;gap:5px;}
+        .lp-whatsapp-float{position:fixed;right:20px;bottom:20px;width:50px;height:50px;border-radius:50%;background:#25d366;color:#fff;display:flex;align-items:center;justify-content:center;font-size:24px;z-index:1000;}
         </style>
         <div class="lp-onepage-wrapper">
         <header class="lp-onepage-header">
@@ -228,11 +233,10 @@ if ( have_posts() ) {
                     <?php foreach ( $menu_items as $slug => $label ) : ?>
                         <li><a href="#<?php echo esc_attr( $slug ); ?>"><?php echo esc_html( $label ); ?></a></li>
                     <?php endforeach; ?>
-                    <?php if ( lp_onepage_on( $contact_show ) && ! empty( $phone ) ) : ?>
+                    <?php if ( ! empty( $phone ) ) : ?>
                         <li class="lp-nav-phone"><a href="tel:<?php echo esc_attr( $phone ); ?>"><i class="fa fa-phone"></i><?php echo esc_html( $phone ); ?></a></li>
                     <?php endif; ?>
-                    <?php if ( lp_onepage_on( $contact_show ) && ! empty( $whatsapp ) ) :
-                        $wa_link = 'https://api.whatsapp.com/send?phone=' . $whatsapp; ?>
+                    <?php if ( ! empty( $whatsapp ) ) : ?>
                         <li class="lp-nav-whatsapp"><a href="<?php echo esc_url( $wa_link ); ?>" target="_blank"><i class="fa fa-whatsapp"></i><?php echo esc_html( $whatsapp ); ?></a></li>
                     <?php endif; ?>
                 </ul>
@@ -381,17 +385,19 @@ if ( have_posts() ) {
                     <?php if ( ! empty( $locations ) && lp_onepage_on( $location_show ) ) : ?>
                         <li class="lp-contact-location"><i class="fa fa-map-marker"></i><?php echo esc_html( $locations[0]->name ); ?></li>
                     <?php endif; ?>
+                    <?php if ( ! empty( $categories ) ) : ?>
+                        <li class="lp-contact-category"><i class="fa fa-folder-open"></i><?php echo esc_html( $categories[0]->name ); ?></li>
+                    <?php endif; ?>
                     <?php if ( lp_onepage_on( $location_show ) && ! empty( $address ) ) : ?>
                         <li class="lp-contact-address"><i class="fa fa-location-arrow"></i><?php echo esc_html( $address ); ?><?php if ( ! empty( $latitude ) && ! empty( $longitude ) ) : ?> <a href="https://www.google.com/maps/search/?api=1&amp;query=<?php echo esc_attr( $latitude ); ?>,<?php echo esc_attr( $longitude ); ?>" target="_blank"><?php echo esc_html__( 'Yol Tarifi Al', 'listingpro' ); ?></a><?php endif; ?></li>
                     <?php endif; ?>
                     <?php if ( lp_onepage_on( $contact_show ) && 'yes' === $email_switcher && ! empty( $email ) ) : ?>
                         <li class="lp-contact-email"><i class="fa fa-envelope"></i><a href="mailto:<?php echo esc_attr( $email ); ?>"><?php echo esc_html( $email ); ?></a></li>
                     <?php endif; ?>
-                    <?php if ( lp_onepage_on( $contact_show ) && ! empty( $phone ) ) : ?>
+                    <?php if ( ! empty( $phone ) ) : ?>
                         <li class="lp-contact-phone"><i class="fa fa-phone"></i><a href="tel:<?php echo esc_attr( $phone ); ?>"><?php echo esc_html( $phone ); ?></a></li>
                     <?php endif; ?>
-                    <?php if ( lp_onepage_on( $contact_show ) && ! empty( $whatsapp ) ) :
-                        $wa_link = 'https://api.whatsapp.com/send?phone=' . $whatsapp; ?>
+                    <?php if ( ! empty( $whatsapp ) ) : ?>
                         <li class="lp-contact-whatsapp"><i class="fa fa-whatsapp"></i><a href="<?php echo esc_url( $wa_link ); ?>" target="_blank"><?php echo esc_html( $whatsapp ); ?></a></li>
                     <?php endif; ?>
                     <?php if ( lp_onepage_on( $website_show ) && ! empty( $website ) ) : ?>
@@ -419,6 +425,9 @@ if ( have_posts() ) {
                 <?php get_template_part( 'templates/single-list/listing-details-style3/sidebar/lead-form' ); ?>
             </div>
         </section>
+        <?php if ( ! empty( $wa_link ) ) : ?>
+            <a class="lp-whatsapp-float" href="<?php echo esc_url( $wa_link ); ?>" target="_blank"><i class="fa fa-whatsapp"></i></a>
+        <?php endif; ?>
 
         <script>
         jQuery(function($){

--- a/templates/listing-onepage.php
+++ b/templates/listing-onepage.php
@@ -88,7 +88,12 @@ if ( have_posts() ) {
 
         $locations  = get_the_terms( get_the_ID(), 'location' );
         $categories = get_the_terms( get_the_ID(), 'listing-category' );
-        $price_html = function_exists( 'listingpro_price_dynesty' ) ? listingpro_price_dynesty( get_the_ID() ) : '';
+        $price_html = '';
+        if ( function_exists( 'listingpro_price_dynesty' ) ) {
+            ob_start();
+            listingpro_price_dynesty( get_the_ID() );
+            $price_html = ob_get_clean();
+        }
 
         $lp_title    = get_the_title();
         $tagline_text = lp_onepage_meta( 'tagline_text' );
@@ -194,7 +199,10 @@ if ( have_posts() ) {
         .lp-gallery-grid img{width:100%;height:auto;border-radius:4px;}
         #singlepostmap{width:100%;height:300px;border-radius:4px;}
         .lp-contact-list{list-style:none;margin:0;padding:0;}
-        .lp-contact-list li{margin-bottom:8px;}
+        .lp-contact-list li{margin-bottom:8px;display:flex;align-items:center;gap:8px;}
+        .lp-contact-list i{width:16px;text-align:center;}
+        .lp-contact-list a{color:inherit;text-decoration:none;}
+        .lp-contact-list a:hover{text-decoration:underline;}
         .lp-social-list{list-style:none;margin:20px 0 0;padding:0;display:flex;gap:10px;justify-content:center;}
         .lp-social-list a{text-decoration:none;font-size:20px;}
         .lp-listing-tagline{margin-top:10px;font-size:18px;color:#555;}
@@ -348,21 +356,27 @@ if ( have_posts() ) {
             <div class="container">
                 <h2 class="lp-section-title"><?php echo esc_html( $menu_items['contact'] ); ?></h2>
                 <ul class="lp-contact-list">
+                    <?php if ( ! empty( $locations ) && lp_onepage_on( $location_show ) ) : ?>
+                        <li class="lp-contact-location"><i class="fa fa-map-marker"></i><?php echo esc_html( $locations[0]->name ); ?></li>
+                    <?php endif; ?>
                     <?php if ( lp_onepage_on( $location_show ) && ! empty( $address ) ) : ?>
-                        <li class="lp-contact-address"><?php echo esc_html( $address ); ?></li>
+                        <li class="lp-contact-address"><i class="fa fa-location-arrow"></i><?php echo esc_html( $address ); ?><?php if ( ! empty( $latitude ) && ! empty( $longitude ) ) : ?> <a href="https://www.google.com/maps/search/?api=1&amp;query=<?php echo esc_attr( $latitude ); ?>,<?php echo esc_attr( $longitude ); ?>" target="_blank"><?php echo esc_html__( 'Yol Tarifi Al', 'listingpro' ); ?></a><?php endif; ?></li>
                     <?php endif; ?>
                     <?php if ( lp_onepage_on( $contact_show ) && ! empty( $email ) ) : ?>
-                        <li class="lp-contact-email"><a href="mailto:<?php echo esc_attr( $email ); ?>"><?php echo esc_html( $email ); ?></a></li>
+                        <li class="lp-contact-email"><i class="fa fa-envelope"></i><a href="mailto:<?php echo esc_attr( $email ); ?>"><?php echo esc_html( $email ); ?></a></li>
                     <?php endif; ?>
                     <?php if ( lp_onepage_on( $contact_show ) && ! empty( $phone ) ) : ?>
-                        <li class="lp-contact-phone"><?php echo esc_html( $phone ); ?></li>
+                        <li class="lp-contact-phone"><i class="fa fa-phone"></i><a href="tel:<?php echo esc_attr( $phone ); ?>"><?php echo esc_html( $phone ); ?></a></li>
                     <?php endif; ?>
                     <?php if ( lp_onepage_on( $contact_show ) && ! empty( $whatsapp ) ) :
                         $wa_link = 'https://api.whatsapp.com/send?phone=' . $whatsapp; ?>
-                        <li class="lp-contact-whatsapp"><a href="<?php echo esc_url( $wa_link ); ?>" target="_blank"><?php echo esc_html( $whatsapp ); ?></a></li>
+                        <li class="lp-contact-whatsapp"><i class="fa fa-whatsapp"></i><a href="<?php echo esc_url( $wa_link ); ?>" target="_blank"><?php echo esc_html( $whatsapp ); ?></a></li>
                     <?php endif; ?>
                     <?php if ( lp_onepage_on( $website_show ) && ! empty( $website ) ) : ?>
-                        <li class="lp-contact-website"><a href="<?php echo esc_url( $website ); ?>" target="_blank"><?php echo esc_html( $website ); ?></a></li>
+                        <li class="lp-contact-website"><i class="fa fa-globe"></i><a href="<?php echo esc_url( $website ); ?>" target="_blank"><?php echo esc_html( $website ); ?></a></li>
+                    <?php endif; ?>
+                    <?php if ( ! empty( $price_html ) ) : ?>
+                        <li class="lp-contact-price"><?php echo $price_html; ?></li>
                     <?php endif; ?>
                 </ul>
                 <?php if ( lp_onepage_on( $social_show ) && ( $facebook || $twitter || $linkedin || $youtube || $instagram ) ) : ?>
@@ -373,9 +387,6 @@ if ( have_posts() ) {
                         <?php if ( ! empty( $youtube ) ) : ?><li><a href="<?php echo esc_url( $youtube ); ?>" target="_blank"><i class="fa fa-youtube"></i></a></li><?php endif; ?>
                         <?php if ( ! empty( $instagram ) ) : ?><li><a href="<?php echo esc_url( $instagram ); ?>" target="_blank"><i class="fa fa-instagram"></i></a></li><?php endif; ?>
                     </ul>
-                <?php endif; ?>
-                <?php if ( ! empty( $price_html ) ) : ?>
-                    <div class="lp-contact-price"><?php echo $price_html; ?></div>
                 <?php endif; ?>
                 <?php get_template_part( 'templates/single-list/listing-details-style3/sidebar/lead-form' ); ?>
             </div>

--- a/templates/listing-onepage.php
+++ b/templates/listing-onepage.php
@@ -168,25 +168,29 @@ if ( have_posts() ) {
         }
         ?>
         <style>
-        .lp-onepage-header{display:flex;align-items:center;justify-content:space-between;gap:30px;margin-bottom:40px;}
+        .lp-onepage-header{position:sticky;top:0;background:#fff;z-index:999;border-bottom:1px solid #eee;}
+        .lp-onepage-header-inner{display:flex;align-items:center;justify-content:space-between;gap:30px;padding:15px 0;}
         .lp-onepage-logo img{max-height:80px;width:auto;}
-        .lp-onepage-nav ul{list-style:none;margin:0;padding:0;display:flex;gap:20px;}
-        .lp-onepage-nav a{text-decoration:none;color:inherit;font-weight:600;}
-        .lp-section{margin-bottom:60px;}
-        .lp-section-title{margin:0 0 20px;font-size:28px;font-weight:700;}
+        .lp-onepage-nav ul{list-style:none;margin:0;padding:0;display:flex;gap:30px;}
+        .lp-onepage-nav a{text-decoration:none;color:#333;font-weight:600;}
+        .lp-onepage-nav a:hover{color:#0073aa;}
+        .lp-section{padding:60px 0;}
+        .lp-section .container{max-width:1170px;margin:0 auto;}
+        .lp-section-title{margin:0 0 30px;font-size:28px;font-weight:700;text-align:center;}
         .lp-gallery-grid{display:flex;flex-wrap:wrap;gap:15px;}
         .lp-gallery-grid img{max-width:100%;height:auto;border-radius:4px;}
         #singlepostmap{width:100%;height:300px;border-radius:4px;}
         .lp-contact-list{list-style:none;margin:0;padding:0;}
         .lp-contact-list li{margin-bottom:8px;}
-        .lp-social-list{list-style:none;margin:20px 0 0;padding:0;display:flex;gap:10px;}
+        .lp-social-list{list-style:none;margin:20px 0 0;padding:0;display:flex;gap:10px;justify-content:center;}
         .lp-social-list a{text-decoration:none;font-size:20px;}
         .lp-listing-tagline{margin-top:10px;font-size:18px;color:#555;}
-        .lp-home-meta{list-style:none;margin:10px 0 0;padding:0;display:flex;gap:15px;font-size:14px;color:#777;}
+        .lp-home-meta{list-style:none;margin:10px 0 0;padding:0;display:flex;gap:15px;font-size:14px;color:#777;justify-content:center;}
         .lp-home-meta li{display:flex;align-items:center;gap:5px;}
         </style>
         <div class="lp-onepage-wrapper">
         <header class="lp-onepage-header">
+            <div class="container lp-onepage-header-inner">
             <?php if ( ! empty( $business_logo_url ) ) : ?>
                 <div class="lp-onepage-logo"><img src="<?php echo esc_attr( $business_logo_url ); ?>" alt="<?php esc_attr_e( 'Listing Logo', 'listingpro' ); ?>"></div>
             <?php else : ?>
@@ -199,6 +203,7 @@ if ( have_posts() ) {
                     <?php endforeach; ?>
                 </ul>
             </nav>
+            </div>
         </header>
 
         <?php
@@ -226,8 +231,10 @@ if ( have_posts() ) {
                     if ( isset( $menu_items['about'] ) ) {
                         ?>
                         <section id="about" class="lp-section lp-section-about">
-                            <h2 class="lp-section-title"><?php echo esc_html( $menu_items['about'] ); ?></h2>
-                            <?php echo apply_filters( 'the_content', $description ); ?>
+                            <div class="container">
+                                <h2 class="lp-section-title"><?php echo esc_html( $menu_items['about'] ); ?></h2>
+                                <?php echo apply_filters( 'the_content', $description ); ?>
+                            </div>
                         </section>
                         <?php
                     }
@@ -236,12 +243,14 @@ if ( have_posts() ) {
                     if ( isset( $menu_items['services'] ) ) {
                         ?>
                         <section id="services" class="lp-section lp-section-services">
-                            <h2 class="lp-section-title"><?php echo esc_html( $menu_items['services'] ); ?></h2>
-                            <ul>
-                            <?php foreach ( $services as $term ) : ?>
-                                <li><?php echo esc_html( $term->name ); ?></li>
-                            <?php endforeach; ?>
-                            </ul>
+                            <div class="container">
+                                <h2 class="lp-section-title"><?php echo esc_html( $menu_items['services'] ); ?></h2>
+                                <ul>
+                                <?php foreach ( $services as $term ) : ?>
+                                    <li><?php echo esc_html( $term->name ); ?></li>
+                                <?php endforeach; ?>
+                                </ul>
+                            </div>
                         </section>
                         <?php
                     }
@@ -250,9 +259,11 @@ if ( have_posts() ) {
                     if ( isset( $menu_items['gallery'] ) ) {
                         ?>
                         <section id="gallery" class="lp-section lp-section-gallery">
-                            <h2 class="lp-section-title"><?php echo esc_html( $menu_items['gallery'] ); ?></h2>
-                            <div class="lp-gallery-grid">
-                            <?php foreach ( $gallery_ids as $image_id ) { echo wp_get_attachment_image( $image_id, 'large' ); } ?>
+                            <div class="container">
+                                <h2 class="lp-section-title"><?php echo esc_html( $menu_items['gallery'] ); ?></h2>
+                                <div class="lp-gallery-grid">
+                                <?php foreach ( $gallery_ids as $image_id ) { echo wp_get_attachment_image( $image_id, 'large' ); } ?>
+                                </div>
                             </div>
                         </section>
                         <?php
@@ -262,8 +273,10 @@ if ( have_posts() ) {
                     if ( isset( $menu_items['video'] ) ) {
                         ?>
                         <section id="video" class="lp-section lp-section-video">
-                            <h2 class="lp-section-title"><?php echo esc_html( $menu_items['video'] ); ?></h2>
-                            <?php echo apply_filters( 'the_content', (string) $video ); ?>
+                            <div class="container">
+                                <h2 class="lp-section-title"><?php echo esc_html( $menu_items['video'] ); ?></h2>
+                                <?php echo apply_filters( 'the_content', (string) $video ); ?>
+                            </div>
                         </section>
                         <?php
                     }
@@ -275,47 +288,53 @@ if ( have_posts() ) {
         <?php if ( isset( $menu_items['map'] ) ) :
             $lp_map_pin = $listingpro_options['lp_map_pin']['url']; ?>
             <section id="map" class="lp-section lp-section-map">
-                <h2 class="lp-section-title"><?php echo esc_html( $menu_items['map'] ); ?></h2>
-                <div id="singlepostmap" class="singlemap" data-lat="<?php echo esc_attr( $latitude ); ?>" data-lan="<?php echo esc_attr( $longitude ); ?>" data-pinicon="<?php echo esc_attr( $lp_map_pin ); ?>"></div>
+                <div class="container">
+                    <h2 class="lp-section-title"><?php echo esc_html( $menu_items['map'] ); ?></h2>
+                    <div id="singlepostmap" class="singlemap" data-lat="<?php echo esc_attr( $latitude ); ?>" data-lan="<?php echo esc_attr( $longitude ); ?>" data-pinicon="<?php echo esc_attr( $lp_map_pin ); ?>"></div>
+                </div>
             </section>
         <?php endif; ?>
 
         <?php if ( isset( $menu_items['hours'] ) ) : ?>
             <section id="hours" class="lp-section lp-section-hours">
-                <h2 class="lp-section-title"><?php echo esc_html( $menu_items['hours'] ); ?></h2>
-                <?php get_template_part( 'include/timings' ); ?>
+                <div class="container">
+                    <h2 class="lp-section-title"><?php echo esc_html( $menu_items['hours'] ); ?></h2>
+                    <?php get_template_part( 'include/timings' ); ?>
+                </div>
             </section>
         <?php endif; ?>
 
         <section id="contact" class="lp-section lp-section-contact">
-            <h2 class="lp-section-title"><?php echo esc_html( $menu_items['contact'] ); ?></h2>
-            <ul class="lp-contact-list">
-                <?php if ( 'true' === $location_show && ! empty( $address ) ) : ?>
-                    <li class="lp-contact-address"><?php echo esc_html( $address ); ?></li>
-                <?php endif; ?>
-                <?php if ( 'true' === $contact_show && ! empty( $email ) ) : ?>
-                    <li class="lp-contact-email"><a href="mailto:<?php echo esc_attr( $email ); ?>"><?php echo esc_html( $email ); ?></a></li>
-                <?php endif; ?>
-                <?php if ( 'true' === $contact_show && ! empty( $phone ) ) : ?>
-                    <li class="lp-contact-phone"><?php echo esc_html( $phone ); ?></li>
-                <?php endif; ?>
-                <?php if ( 'true' === $contact_show && ! empty( $whatsapp ) ) :
-                    $wa_link = 'https://api.whatsapp.com/send?phone=' . $whatsapp; ?>
-                    <li class="lp-contact-whatsapp"><a href="<?php echo esc_url( $wa_link ); ?>" target="_blank"><?php echo esc_html( $whatsapp ); ?></a></li>
-                <?php endif; ?>
-                <?php if ( 'true' === $website_show && ! empty( $website ) ) : ?>
-                    <li class="lp-contact-website"><a href="<?php echo esc_url( $website ); ?>" target="_blank"><?php echo esc_html( $website ); ?></a></li>
-                <?php endif; ?>
-            </ul>
-            <?php if ( 'true' === $social_show && ( $facebook || $twitter || $linkedin || $youtube || $instagram ) ) : ?>
-                <ul class="lp-social-list">
-                    <?php if ( ! empty( $facebook ) ) : ?><li><a href="<?php echo esc_url( $facebook ); ?>" target="_blank"><i class="fa-brands fa-square-facebook"></i></a></li><?php endif; ?>
-                    <?php if ( ! empty( $twitter ) ) : ?><li><a href="<?php echo esc_url( $twitter ); ?>" target="_blank"><i class="fa-brands fa-square-x-twitter"></i></a></li><?php endif; ?>
-                    <?php if ( ! empty( $linkedin ) ) : ?><li><a href="<?php echo esc_url( $linkedin ); ?>" target="_blank"><i class="fa-brands fa-linkedin"></i></a></li><?php endif; ?>
-                    <?php if ( ! empty( $youtube ) ) : ?><li><a href="<?php echo esc_url( $youtube ); ?>" target="_blank"><i class="fa-brands fa-youtube"></i></a></li><?php endif; ?>
-                    <?php if ( ! empty( $instagram ) ) : ?><li><a href="<?php echo esc_url( $instagram ); ?>" target="_blank"><i class="fa-brands fa-square-instagram"></i></a></li><?php endif; ?>
+            <div class="container">
+                <h2 class="lp-section-title"><?php echo esc_html( $menu_items['contact'] ); ?></h2>
+                <ul class="lp-contact-list">
+                    <?php if ( 'true' === $location_show && ! empty( $address ) ) : ?>
+                        <li class="lp-contact-address"><?php echo esc_html( $address ); ?></li>
+                    <?php endif; ?>
+                    <?php if ( 'true' === $contact_show && ! empty( $email ) ) : ?>
+                        <li class="lp-contact-email"><a href="mailto:<?php echo esc_attr( $email ); ?>"><?php echo esc_html( $email ); ?></a></li>
+                    <?php endif; ?>
+                    <?php if ( 'true' === $contact_show && ! empty( $phone ) ) : ?>
+                        <li class="lp-contact-phone"><?php echo esc_html( $phone ); ?></li>
+                    <?php endif; ?>
+                    <?php if ( 'true' === $contact_show && ! empty( $whatsapp ) ) :
+                        $wa_link = 'https://api.whatsapp.com/send?phone=' . $whatsapp; ?>
+                        <li class="lp-contact-whatsapp"><a href="<?php echo esc_url( $wa_link ); ?>" target="_blank"><?php echo esc_html( $whatsapp ); ?></a></li>
+                    <?php endif; ?>
+                    <?php if ( 'true' === $website_show && ! empty( $website ) ) : ?>
+                        <li class="lp-contact-website"><a href="<?php echo esc_url( $website ); ?>" target="_blank"><?php echo esc_html( $website ); ?></a></li>
+                    <?php endif; ?>
                 </ul>
-            <?php endif; ?>
+                <?php if ( 'true' === $social_show && ( $facebook || $twitter || $linkedin || $youtube || $instagram ) ) : ?>
+                    <ul class="lp-social-list">
+                        <?php if ( ! empty( $facebook ) ) : ?><li><a href="<?php echo esc_url( $facebook ); ?>" target="_blank"><i class="fa-brands fa-square-facebook"></i></a></li><?php endif; ?>
+                        <?php if ( ! empty( $twitter ) ) : ?><li><a href="<?php echo esc_url( $twitter ); ?>" target="_blank"><i class="fa-brands fa-square-x-twitter"></i></a></li><?php endif; ?>
+                        <?php if ( ! empty( $linkedin ) ) : ?><li><a href="<?php echo esc_url( $linkedin ); ?>" target="_blank"><i class="fa-brands fa-linkedin"></i></a></li><?php endif; ?>
+                        <?php if ( ! empty( $youtube ) ) : ?><li><a href="<?php echo esc_url( $youtube ); ?>" target="_blank"><i class="fa-brands fa-youtube"></i></a></li><?php endif; ?>
+                        <?php if ( ! empty( $instagram ) ) : ?><li><a href="<?php echo esc_url( $instagram ); ?>" target="_blank"><i class="fa-brands fa-square-instagram"></i></a></li><?php endif; ?>
+                    </ul>
+                <?php endif; ?>
+            </div>
         </section>
 
         <script>

--- a/templates/listing-onepage.php
+++ b/templates/listing-onepage.php
@@ -190,7 +190,8 @@ if ( have_posts() ) {
         .lp-section .container{max-width:1170px;margin:0 auto;}
         .lp-section-title{margin:0 0 30px;font-size:28px;font-weight:700;text-align:center;}
         .lp-gallery-grid{display:flex;flex-wrap:wrap;gap:15px;}
-        .lp-gallery-grid img{max-width:100%;height:auto;border-radius:4px;}
+        .lp-gallery-item{flex:1 1 calc(33.333% - 10px);}
+        .lp-gallery-grid img{width:100%;height:auto;border-radius:4px;}
         #singlepostmap{width:100%;height:300px;border-radius:4px;}
         .lp-contact-list{list-style:none;margin:0;padding:0;}
         .lp-contact-list li{margin-bottom:8px;}
@@ -283,11 +284,11 @@ if ( have_posts() ) {
                         <section id="gallery" class="lp-section lp-section-gallery">
                             <div class="container">
                                 <h2 class="lp-section-title"><?php echo esc_html( $menu_items['gallery'] ); ?></h2>
-                                <div class="listing-slide2 img_<?php echo esc_attr( $num_gallery ); ?>" data-images-num="<?php echo esc_attr( $num_gallery ); ?>">
+                                <div class="lp-gallery-grid">
                                 <?php foreach ( $gallery_ids as $image_id ) :
                                     $img_full = wp_get_attachment_image_src( $image_id, 'full' );
                                     if ( $img_full ) : ?>
-                                        <div class="slide"><img src="<?php echo esc_url( $img_full[0] ); ?>" alt="<?php echo esc_attr( $lp_title ); ?>"></div>
+                                        <div class="lp-gallery-item"><img src="<?php echo esc_url( $img_full[0] ); ?>" alt="<?php echo esc_attr( $lp_title ); ?>"></div>
                                     <?php endif;
                                 endforeach; ?>
                                 </div>

--- a/templates/listing-onepage.php
+++ b/templates/listing-onepage.php
@@ -255,6 +255,23 @@ if ( have_posts() ) {
                 </div>
             </div>
         </section>
+        <?php if ( ! empty( $locations ) || ! empty( $categories ) || ! empty( $price_html ) ) : ?>
+        <div class="lp-home-meta-wrap">
+            <div class="container">
+                <ul class="lp-home-meta">
+                    <?php if ( ! empty( $locations ) ) : ?>
+                        <li><i class="fa fa-map-marker"></i><?php echo esc_html( $locations[0]->name ); ?></li>
+                    <?php endif; ?>
+                    <?php if ( ! empty( $categories ) ) : ?>
+                        <li><i class="fa fa-folder-open"></i><?php echo esc_html( $categories[0]->name ); ?></li>
+                    <?php endif; ?>
+                    <?php if ( ! empty( $price_html ) ) : ?>
+                        <li><?php echo $price_html; ?></li>
+                    <?php endif; ?>
+                </ul>
+            </div>
+        </div>
+        <?php endif; ?>
 
         <?php foreach ( $layout_general as $section_key ) {
             switch ( $section_key ) {

--- a/templates/listing-onepage.php
+++ b/templates/listing-onepage.php
@@ -36,6 +36,7 @@ if ( have_posts() ) {
         $services = wp_get_post_terms( get_the_ID(), 'features' );
         $gallery_ids = get_post_meta( get_the_ID(), 'gallery_image_ids', true );
         $gallery_ids = ! empty( $gallery_ids ) ? array_filter( explode( ',', $gallery_ids ) ) : array();
+        $num_gallery = count( $gallery_ids );
         $video      = lp_onepage_meta_by_id( 'video', get_the_ID() );
         if ( empty( $video ) ) {
             $video = lp_onepage_meta( 'lp_video_embed' );
@@ -276,8 +277,13 @@ if ( have_posts() ) {
                         <section id="gallery" class="lp-section lp-section-gallery">
                             <div class="container">
                                 <h2 class="lp-section-title"><?php echo esc_html( $menu_items['gallery'] ); ?></h2>
-                                <div class="lp-gallery-grid">
-                                <?php foreach ( $gallery_ids as $image_id ) { echo wp_get_attachment_image( $image_id, 'large' ); } ?>
+                                <div class="listing-slide2 img_<?php echo esc_attr( $num_gallery ); ?>" data-images-num="<?php echo esc_attr( $num_gallery ); ?>">
+                                <?php foreach ( $gallery_ids as $image_id ) :
+                                    $img_full = wp_get_attachment_image_src( $image_id, 'full' );
+                                    if ( $img_full ) : ?>
+                                        <div class="slide"><img src="<?php echo esc_url( $img_full[0] ); ?>" alt="<?php echo esc_attr( $lp_title ); ?>"></div>
+                                    <?php endif;
+                                endforeach; ?>
                                 </div>
                             </div>
                         </section>
@@ -361,6 +367,10 @@ if ( have_posts() ) {
                         <?php if ( ! empty( $instagram ) ) : ?><li><a href="<?php echo esc_url( $instagram ); ?>" target="_blank"><i class="fa fa-instagram"></i></a></li><?php endif; ?>
                     </ul>
                 <?php endif; ?>
+                <?php if ( ! empty( $price_html ) ) : ?>
+                    <div class="lp-contact-price"><?php echo $price_html; ?></div>
+                <?php endif; ?>
+                <?php get_template_part( 'templates/single-list/listing-details-style3/sidebar/lead-form' ); ?>
             </div>
         </section>
 

--- a/templates/listing-onepage.php
+++ b/templates/listing-onepage.php
@@ -177,7 +177,7 @@ if ( have_posts() ) {
         .lp-onepage-logo img{width:60px;height:60px;border-radius:50%;object-fit:cover;}
         .lp-onepage-name{font-weight:700;font-size:20px;}
         .lp-onepage-nav ul{list-style:none;margin:0;padding:0;display:flex;gap:30px;}
-        .lp-onepage-nav a{text-decoration:none;color:#333;font-weight:600;}
+        .lp-onepage-nav a{text-decoration:none;color:#333;font-weight:600;display:flex;align-items:center;gap:5px;}
         .lp-onepage-nav a:hover{color:#0073aa;}
         .lp-section{padding:60px 0;}
         .lp-section .container{max-width:1170px;margin:0 auto;}
@@ -209,6 +209,13 @@ if ( have_posts() ) {
                     <?php foreach ( $menu_items as $slug => $label ) : ?>
                         <li><a href="#<?php echo esc_attr( $slug ); ?>"><?php echo esc_html( $label ); ?></a></li>
                     <?php endforeach; ?>
+                    <?php if ( 'true' === $contact_show && ! empty( $phone ) ) : ?>
+                        <li class="lp-nav-phone"><a href="tel:<?php echo esc_attr( $phone ); ?>"><i class="fa fa-phone"></i><?php echo esc_html( $phone ); ?></a></li>
+                    <?php endif; ?>
+                    <?php if ( 'true' === $contact_show && ! empty( $whatsapp ) ) :
+                        $wa_link = 'https://api.whatsapp.com/send?phone=' . $whatsapp; ?>
+                        <li class="lp-nav-whatsapp"><a href="<?php echo esc_url( $wa_link ); ?>" target="_blank"><i class="fa fa-whatsapp"></i><?php echo esc_html( $whatsapp ); ?></a></li>
+                    <?php endif; ?>
                 </ul>
             </nav>
             </div>

--- a/templates/listing-onepage.php
+++ b/templates/listing-onepage.php
@@ -66,8 +66,10 @@ if ( have_posts() ) {
         $website_show  = get_post_meta( $plan_id, 'listingproc_website', true );
         $hours_show    = get_post_meta( $plan_id, 'listingproc_bhours', true );
         $faqs_show     = get_post_meta( $plan_id, 'listingproc_faq', true );
+        $price_show    = get_post_meta( $plan_id, 'listingproc_price', true );
+        $tags_show     = get_post_meta( $plan_id, 'listingproc_tag_key', true );
         if ( 'none' === $plan_id ) {
-            $map_show = $social_show = $location_show = $contact_show = $website_show = $hours_show = $faqs_show = 'true';
+            $map_show = $social_show = $location_show = $contact_show = $website_show = $hours_show = $faqs_show = $price_show = $tags_show = 'true';
         }
 
         $address   = lp_onepage_meta( 'gAddress' );
@@ -84,6 +86,8 @@ if ( have_posts() ) {
         $hours     = lp_onepage_meta( 'business_hours' );
         $faqs      = lp_onepage_meta_by_id( 'faqs', get_the_ID() );
         $email_switcher = function_exists( 'lp_theme_option' ) ? lp_theme_option( 'listingpro_email_display_switch' ) : 'yes';
+
+        $tags_terms = get_the_terms( get_the_ID(), 'list-tags' );
 
         $facebook  = lp_onepage_meta( 'facebook' );
         $twitter   = lp_onepage_meta( 'twitter' );
@@ -135,6 +139,19 @@ if ( have_posts() ) {
             $rating_num_clr = 'level4';
         }
         $resurva_url = get_post_meta( get_the_ID(), 'resurva_url', true );
+        $post_author_id = get_post_field( 'post_author', get_the_ID() );
+        $menuOption = false;
+        $menuMeta = get_post_meta( get_the_ID(), 'menu_listing', true );
+        if ( ! empty( $menuMeta ) ) {
+            $menuOption = true;
+        }
+        $timekit = false;
+        $timekit_booking = get_post_meta( get_the_ID(), 'timekit_bookings', true );
+        if ( ! empty( $timekit_booking ) ) {
+            $timekit = true;
+        }
+        $announcements_raw = get_post_meta( get_the_ID(), 'lp_listing_announcements', true );
+        $has_announcements = is_array( $announcements_raw ) && count( $announcements_raw ) > 0;
 
         foreach ( $layout_general as $section_key ) {
             switch ( $section_key ) {
@@ -161,6 +178,39 @@ if ( have_posts() ) {
                 case 'lp_faqs_section':
                     if ( lp_onepage_on( $faqs_show ) && ! empty( $faqs ) && ! empty( $faqs['faq'][1] ) ) {
                         $menu_items['faq'] = __( 'SSS', 'listingpro' );
+                    }
+                    break;
+                case 'lp_announcements_section':
+                    if ( $has_announcements ) {
+                        $menu_items['announcements'] = __( 'Duyurular', 'listingpro' );
+                    }
+                    break;
+                case 'lp_offers_section':
+                    $menu_items['offers'] = __( 'Fırsatlar', 'listingpro' );
+                    break;
+                case 'lp_menu_section':
+                    if ( $menuOption ) {
+                        $menu_items['menu'] = __( 'Menü', 'listingpro' );
+                    }
+                    break;
+                case 'lp_event_section':
+                    $menu_items['event'] = __( 'Etkinlikler', 'listingpro' );
+                    break;
+                case 'lp_reviews_section':
+                    $menu_items['reviews'] = __( 'Yorumlar', 'listingpro' );
+                    break;
+                case 'lp_reviewform_section':
+                    $menu_items['reviewform'] = __( 'Yorum Yaz', 'listingpro' );
+                    break;
+                case 'lp_features_section':
+                    $menu_items['features'] = __( 'Özellikler', 'listingpro' );
+                    break;
+                case 'lp_additional_section':
+                    $menu_items['additional'] = __( 'Ek Bilgiler', 'listingpro' );
+                    break;
+                case 'lp_booking_section':
+                    if ( $timekit || ! empty( $resurva_url ) || class_exists( 'Listingpro_bookings' ) ) {
+                        $menu_items['booking'] = __( 'Randevu', 'listingpro' );
                     }
                     break;
             }
@@ -355,6 +405,134 @@ if ( have_posts() ) {
                         <?php
                     }
                     break;
+                case 'lp_announcements_section':
+                    if ( isset( $menu_items['announcements'] ) ) {
+                        ?>
+                        <section id="announcements" class="lp-section lp-section-announcements">
+                            <div class="container">
+                                <h2 class="lp-section-title"><?php echo esc_html( $menu_items['announcements'] ); ?></h2>
+                                <?php get_template_part( 'templates/single-list/listing-details-style6/content/list-announcements' ); ?>
+                            </div>
+                        </section>
+                        <?php
+                    }
+                    break;
+                case 'lp_offers_section':
+                    if ( isset( $menu_items['offers'] ) ) {
+                        ?>
+                        <section id="offers" class="lp-section lp-section-offers">
+                            <div class="container">
+                                <h2 class="lp-section-title"><?php echo esc_html( $menu_items['offers'] ); ?></h2>
+                                <?php
+                                $post_author_id = get_post_field( 'post_author', get_the_ID() );
+                                $discount_displayin = get_user_meta( $post_author_id, 'discount_display_area', true );
+                                if ( $discount_displayin == 'content' || empty( $discount_displayin ) ) {
+                                    get_template_part( 'templates/single-list/listing-details-style6/content/list-offer-deals-discount' );
+                                }
+                                ?>
+                            </div>
+                        </section>
+                        <?php
+                    }
+                    break;
+                case 'lp_menu_section':
+                    if ( isset( $menu_items['menu'] ) ) {
+                        ?>
+                        <section id="menu" class="lp-section lp-section-menu">
+                            <div class="container">
+                                <h2 class="lp-section-title"><?php echo esc_html( $menu_items['menu'] ); ?></h2>
+                                <?php get_template_part( 'templates/single-list/listing-details-style6/content/list-menu' ); ?>
+                            </div>
+                        </section>
+                        <?php
+                    }
+                    break;
+                case 'lp_event_section':
+                    if ( isset( $menu_items['event'] ) ) {
+                        ?>
+                        <section id="event" class="lp-section lp-section-event">
+                            <div class="container">
+                                <h2 class="lp-section-title"><?php echo esc_html( $menu_items['event'] ); ?></h2>
+                                <?php $GLOBALS['event_grid_call'] = 'content_area'; get_template_part( 'templates/single-list/event' ); ?>
+                            </div>
+                        </section>
+                        <?php
+                    }
+                    break;
+                case 'lp_reviews_section':
+                    if ( isset( $menu_items['reviews'] ) ) {
+                        ?>
+                        <section id="reviews" class="lp-section lp-section-reviews">
+                            <div class="container">
+                                <h2 class="lp-section-title"><?php echo esc_html( $menu_items['reviews'] ); ?></h2>
+                                <?php get_template_part( 'templates/single-list/listing-details-style6/content/reviews' ); ?>
+                            </div>
+                        </section>
+                        <?php
+                    }
+                    break;
+                case 'lp_reviewform_section':
+                    if ( isset( $menu_items['reviewform'] ) ) {
+                        ?>
+                        <section id="reviewform" class="lp-section lp-section-reviewform">
+                            <div class="container">
+                                <h2 class="lp-section-title"><?php echo esc_html( $menu_items['reviewform'] ); ?></h2>
+                                <?php get_template_part( 'templates/single-list/listing-details-style6/content/reviewform' ); ?>
+                            </div>
+                        </section>
+                        <?php
+                    }
+                    break;
+                case 'lp_features_section':
+                    if ( isset( $menu_items['features'] ) ) {
+                        ?>
+                        <section id="features" class="lp-section lp-section-features">
+                            <div class="container">
+                                <h2 class="lp-section-title"><?php echo esc_html( $menu_items['features'] ); ?></h2>
+                                <?php get_template_part( 'templates/single-list/listing-details-style6/content/features' ); ?>
+                            </div>
+                        </section>
+                        <?php
+                    }
+                    break;
+                case 'lp_additional_section':
+                    if ( isset( $menu_items['additional'] ) ) {
+                        ?>
+                        <section id="additional" class="lp-section lp-section-additional">
+                            <div class="container">
+                                <h2 class="lp-section-title"><?php echo esc_html( $menu_items['additional'] ); ?></h2>
+                                <?php get_template_part( 'templates/single-list/listing-details-style6/content/additional' ); ?>
+                            </div>
+                        </section>
+                        <?php
+                    }
+                    break;
+                case 'lp_booking_section':
+                    if ( isset( $menu_items['booking'] ) ) {
+                        ?>
+                        <section id="booking" class="lp-section lp-section-booking">
+                            <div class="container">
+                                <?php
+                                if ( class_exists( 'Listingpro_bookings' ) ) {
+                                    include WP_CONTENT_DIR . '/plugins/listingpro-bookings/templates/bookings.php';
+                                } elseif ( ! empty( $resurva_url ) ) {
+                                    echo '<iframe src="' . esc_url( $resurva_url ) . '" frameborder="0" style="width:100%;height:600px"></iframe>';
+                                }
+                                ?>
+                            </div>
+                        </section>
+                        <?php
+                    }
+                    break;
+                case 'lp_quicks_section':
+                    ?>
+                    <section id="quicks" class="lp-section lp-section-quicks">
+                        <div class="container">
+                            <?php get_template_part( 'templates/single-list/listing-details-style6/sidebar/quicks' ); ?>
+                        </div>
+                    </section>
+                    <?php
+                    break;
             }
         }
         ?>
@@ -403,8 +581,11 @@ if ( have_posts() ) {
                     <?php if ( lp_onepage_on( $website_show ) && ! empty( $website ) ) : ?>
                         <li class="lp-contact-website"><i class="fa fa-globe"></i><a href="<?php echo esc_url( $website ); ?>" target="_blank"><?php echo esc_html( $website ); ?></a></li>
                     <?php endif; ?>
-                    <?php if ( ! empty( $price_html ) ) : ?>
+                    <?php if ( lp_onepage_on( $price_show ) && ! empty( $price_html ) ) : ?>
                         <li class="lp-contact-price"><?php echo $price_html; ?></li>
+                    <?php endif; ?>
+                    <?php if ( lp_onepage_on( $tags_show ) && ! empty( $tags_terms ) ) : ?>
+                        <li class="lp-contact-tags"><i class="fa fa-tags"></i><?php echo esc_html( join( ', ', wp_list_pluck( $tags_terms, 'name' ) ) ); ?></li>
                     <?php endif; ?>
                 </ul>
                 <?php if ( lp_onepage_on( $social_show ) && ( $facebook || $twitter || $linkedin || $youtube || $instagram ) ) : ?>

--- a/templates/listing-onepage.php
+++ b/templates/listing-onepage.php
@@ -79,6 +79,7 @@ if ( have_posts() ) {
         $longitude = lp_onepage_meta( 'longitude' );
         $hours     = lp_onepage_meta( 'business_hours' );
         $faqs      = lp_onepage_meta_by_id( 'faqs', get_the_ID() );
+        $email_switcher = function_exists( 'lp_theme_option' ) ? lp_theme_option( 'listingpro_email_display_switch' ) : 'yes';
 
         $facebook  = lp_onepage_meta( 'facebook' );
         $twitter   = lp_onepage_meta( 'twitter' );
@@ -197,6 +198,8 @@ if ( have_posts() ) {
         .lp-gallery-grid{display:flex;flex-wrap:wrap;gap:15px;}
         .lp-gallery-item{flex:1 1 calc(33.333% - 10px);}
         .lp-gallery-grid img{width:100%;height:auto;border-radius:4px;}
+        .lp-video-wrapper{position:relative;padding-bottom:73.5%;height:0;overflow:hidden;}
+        .lp-video-wrapper iframe{position:absolute;top:0;left:0;width:100%;height:100%;}
         #singlepostmap{width:100%;height:300px;border-radius:4px;}
         .lp-contact-list{list-style:none;margin:0;padding:0;}
         .lp-contact-list li{margin-bottom:8px;display:flex;align-items:center;gap:8px;}
@@ -328,7 +331,9 @@ if ( have_posts() ) {
                         <section id="video" class="lp-section lp-section-video">
                             <div class="container">
                                 <h2 class="lp-section-title"><?php echo esc_html( $menu_items['video'] ); ?></h2>
+                                <div class="lp-video-wrapper">
                                 <?php echo wp_kses( $video_html, array_merge( wp_kses_allowed_html( 'post' ), array( 'iframe' => array( 'src' => true, 'width' => true, 'height' => true, 'frameborder' => true, 'allowfullscreen' => true ) ) ) ); ?>
+                                </div>
                             </div>
                         </section>
                         <?php
@@ -379,7 +384,7 @@ if ( have_posts() ) {
                     <?php if ( lp_onepage_on( $location_show ) && ! empty( $address ) ) : ?>
                         <li class="lp-contact-address"><i class="fa fa-location-arrow"></i><?php echo esc_html( $address ); ?><?php if ( ! empty( $latitude ) && ! empty( $longitude ) ) : ?> <a href="https://www.google.com/maps/search/?api=1&amp;query=<?php echo esc_attr( $latitude ); ?>,<?php echo esc_attr( $longitude ); ?>" target="_blank"><?php echo esc_html__( 'Yol Tarifi Al', 'listingpro' ); ?></a><?php endif; ?></li>
                     <?php endif; ?>
-                    <?php if ( lp_onepage_on( $contact_show ) && ! empty( $email ) ) : ?>
+                    <?php if ( lp_onepage_on( $contact_show ) && 'yes' === $email_switcher && ! empty( $email ) ) : ?>
                         <li class="lp-contact-email"><i class="fa fa-envelope"></i><a href="mailto:<?php echo esc_attr( $email ); ?>"><?php echo esc_html( $email ); ?></a></li>
                     <?php endif; ?>
                     <?php if ( lp_onepage_on( $contact_show ) && ! empty( $phone ) ) : ?>
@@ -405,6 +410,12 @@ if ( have_posts() ) {
                         <?php if ( ! empty( $instagram ) ) : ?><li><a href="<?php echo esc_url( $instagram ); ?>" target="_blank"><i class="fa fa-instagram"></i></a></li><?php endif; ?>
                     </ul>
                 <?php endif; ?>
+                <?php
+                $additional_pos = isset( $listingpro_options['lp_detail_page_additional_styles'] ) ? $listingpro_options['lp_detail_page_additional_styles'] : '';
+                if ( function_exists( 'listing_all_extra_fields_v2_right' ) && 'right' === $additional_pos ) {
+                    listing_all_extra_fields_v2_right( get_the_ID() );
+                }
+                ?>
                 <?php get_template_part( 'templates/single-list/listing-details-style3/sidebar/lead-form' ); ?>
             </div>
         </section>

--- a/templates/listing-onepage.php
+++ b/templates/listing-onepage.php
@@ -24,6 +24,12 @@ if ( have_posts() ) {
             }
         }
 
+        if ( ! function_exists( 'lp_onepage_on' ) ) {
+            function lp_onepage_on( $flag ) {
+                return ! in_array( $flag, array( 'false', '0', 'off', 'no' ), true );
+            }
+        }
+
         $layout_general = isset( $listingpro_options['lp-detail-page-layout6-content']['general'] )
             ? array_keys( $listingpro_options['lp-detail-page-layout6-content']['general'] )
             : array( 'lp_content_section', 'lp_services_section', 'lp_gallery_section', 'lp_video_section', 'lp_faqs_section' );
@@ -143,21 +149,21 @@ if ( have_posts() ) {
                     }
                     break;
                 case 'lp_faqs_section':
-                    if ( 'true' === $faqs_show && ! empty( $faqs ) && ! empty( $faqs['faq'][1] ) ) {
+                    if ( lp_onepage_on( $faqs_show ) && ! empty( $faqs ) && ! empty( $faqs['faq'][1] ) ) {
                         $menu_items['faq'] = __( 'SSS', 'listingpro' );
                     }
                     break;
             }
         }
 
-        if ( 'true' === $map_show && ! empty( $latitude ) && ! empty( $longitude ) ) {
+        if ( lp_onepage_on( $map_show ) && ! empty( $latitude ) && ! empty( $longitude ) ) {
             $menu_items['map'] = __( 'Harita', 'listingpro' );
         }
         $has_hours = ! empty( $hours );
         if ( is_array( $hours ) ) {
             $has_hours = ! empty( array_filter( $hours ) );
         }
-        if ( 'true' === $hours_show && $has_hours ) {
+        if ( lp_onepage_on( $hours_show ) && $has_hours ) {
             $menu_items['hours'] = __( 'Çalışma Saatleri', 'listingpro' );
         }
         $menu_items['contact'] = __( 'İletişim', 'listingpro' );
@@ -210,10 +216,10 @@ if ( have_posts() ) {
                     <?php foreach ( $menu_items as $slug => $label ) : ?>
                         <li><a href="#<?php echo esc_attr( $slug ); ?>"><?php echo esc_html( $label ); ?></a></li>
                     <?php endforeach; ?>
-                    <?php if ( 'true' === $contact_show && ! empty( $phone ) ) : ?>
+                    <?php if ( lp_onepage_on( $contact_show ) && ! empty( $phone ) ) : ?>
                         <li class="lp-nav-phone"><a href="tel:<?php echo esc_attr( $phone ); ?>"><i class="fa fa-phone"></i><?php echo esc_html( $phone ); ?></a></li>
                     <?php endif; ?>
-                    <?php if ( 'true' === $contact_show && ! empty( $whatsapp ) ) :
+                    <?php if ( lp_onepage_on( $contact_show ) && ! empty( $whatsapp ) ) :
                         $wa_link = 'https://api.whatsapp.com/send?phone=' . $whatsapp; ?>
                         <li class="lp-nav-whatsapp"><a href="<?php echo esc_url( $wa_link ); ?>" target="_blank"><i class="fa fa-whatsapp"></i><?php echo esc_html( $whatsapp ); ?></a></li>
                     <?php endif; ?>
@@ -296,7 +302,7 @@ if ( have_posts() ) {
                         <section id="video" class="lp-section lp-section-video">
                             <div class="container">
                                 <h2 class="lp-section-title"><?php echo esc_html( $menu_items['video'] ); ?></h2>
-                                <?php echo wp_kses_post( $video_html ); ?>
+                                <?php echo wp_kses( $video_html, array_merge( wp_kses_allowed_html( 'post' ), array( 'iframe' => array( 'src' => true, 'width' => true, 'height' => true, 'frameborder' => true, 'allowfullscreen' => true ) ) ) ); ?>
                             </div>
                         </section>
                         <?php
@@ -341,24 +347,24 @@ if ( have_posts() ) {
             <div class="container">
                 <h2 class="lp-section-title"><?php echo esc_html( $menu_items['contact'] ); ?></h2>
                 <ul class="lp-contact-list">
-                    <?php if ( 'true' === $location_show && ! empty( $address ) ) : ?>
+                    <?php if ( lp_onepage_on( $location_show ) && ! empty( $address ) ) : ?>
                         <li class="lp-contact-address"><?php echo esc_html( $address ); ?></li>
                     <?php endif; ?>
-                    <?php if ( 'true' === $contact_show && ! empty( $email ) ) : ?>
+                    <?php if ( lp_onepage_on( $contact_show ) && ! empty( $email ) ) : ?>
                         <li class="lp-contact-email"><a href="mailto:<?php echo esc_attr( $email ); ?>"><?php echo esc_html( $email ); ?></a></li>
                     <?php endif; ?>
-                    <?php if ( 'true' === $contact_show && ! empty( $phone ) ) : ?>
+                    <?php if ( lp_onepage_on( $contact_show ) && ! empty( $phone ) ) : ?>
                         <li class="lp-contact-phone"><?php echo esc_html( $phone ); ?></li>
                     <?php endif; ?>
-                    <?php if ( 'true' === $contact_show && ! empty( $whatsapp ) ) :
+                    <?php if ( lp_onepage_on( $contact_show ) && ! empty( $whatsapp ) ) :
                         $wa_link = 'https://api.whatsapp.com/send?phone=' . $whatsapp; ?>
                         <li class="lp-contact-whatsapp"><a href="<?php echo esc_url( $wa_link ); ?>" target="_blank"><?php echo esc_html( $whatsapp ); ?></a></li>
                     <?php endif; ?>
-                    <?php if ( 'true' === $website_show && ! empty( $website ) ) : ?>
+                    <?php if ( lp_onepage_on( $website_show ) && ! empty( $website ) ) : ?>
                         <li class="lp-contact-website"><a href="<?php echo esc_url( $website ); ?>" target="_blank"><?php echo esc_html( $website ); ?></a></li>
                     <?php endif; ?>
                 </ul>
-                <?php if ( 'true' === $social_show && ( $facebook || $twitter || $linkedin || $youtube || $instagram ) ) : ?>
+                <?php if ( lp_onepage_on( $social_show ) && ( $facebook || $twitter || $linkedin || $youtube || $instagram ) ) : ?>
                     <ul class="lp-social-list">
                         <?php if ( ! empty( $facebook ) ) : ?><li><a href="<?php echo esc_url( $facebook ); ?>" target="_blank"><i class="fa fa-facebook-square"></i></a></li><?php endif; ?>
                         <?php if ( ! empty( $twitter ) ) : ?><li><a href="<?php echo esc_url( $twitter ); ?>" target="_blank"><i class="fa fa-twitter"></i></a></li><?php endif; ?>

--- a/templates/listing-onepage.php
+++ b/templates/listing-onepage.php
@@ -1,0 +1,336 @@
+<?php
+/* One-page listing detail template */
+if ( have_posts() ) {
+    while ( have_posts() ) {
+        the_post();
+        global $listingpro_options;
+
+        if ( ! function_exists( 'lp_onepage_meta' ) ) {
+            function lp_onepage_meta( $key, $post_id = null ) {
+                $id = $post_id ? $post_id : get_the_ID();
+                if ( function_exists( 'listingpro_get_metabox' ) ) {
+                    return listingpro_get_metabox( $key );
+                }
+                return get_post_meta( $id, $key, true );
+            }
+        }
+
+        if ( ! function_exists( 'lp_onepage_meta_by_id' ) ) {
+            function lp_onepage_meta_by_id( $key, $post_id ) {
+                if ( function_exists( 'listing_get_metabox_by_ID' ) ) {
+                    return listing_get_metabox_by_ID( $key, $post_id );
+                }
+                return get_post_meta( $post_id, $key, true );
+            }
+        }
+
+        $layout_keys = isset( $listingpro_options['lp-detail-page-layout6-content']['general'] )
+            ? array_keys( $listingpro_options['lp-detail-page-layout6-content']['general'] )
+            : array();
+        $layout_general = array();
+        foreach ( $layout_keys as $key ) {
+            if ( in_array( $key, array( 'lp_content_section', 'lp_video_section' ), true ) ) {
+                $layout_general[] = $key;
+            }
+        }
+        if ( empty( $layout_general ) ) {
+            $layout_general = array( 'lp_content_section', 'lp_services_section', 'lp_gallery_section', 'lp_video_section' );
+        } else {
+            if ( ( $pos = array_search( 'lp_content_section', $layout_general, true ) ) !== false ) {
+                array_splice( $layout_general, $pos + 1, 0, array( 'lp_services_section', 'lp_gallery_section' ) );
+            } else {
+                array_splice( $layout_general, 0, 0, array( 'lp_services_section', 'lp_gallery_section' ) );
+            }
+        }
+
+        $menu_items = array( 'home' => __( 'Anasayfa', 'listingpro' ) );
+        $description = lp_onepage_meta( 'lp_listing_description' );
+        if ( empty( $description ) ) {
+            $description = get_post_field( 'post_content', get_the_ID() );
+        }
+        $services = wp_get_post_terms( get_the_ID(), 'features' );
+        $gallery_ids = get_post_meta( get_the_ID(), 'gallery_image_ids', true );
+        $gallery_ids = ! empty( $gallery_ids ) ? array_filter( explode( ',', $gallery_ids ) ) : array();
+        $video = lp_onepage_meta_by_id( 'video', get_the_ID() );
+        if ( empty( $video ) ) {
+            $video = lp_onepage_meta( 'lp_video_embed' );
+        }
+
+        $plan_id = lp_onepage_meta_by_id( 'Plan_id', get_the_ID() );
+        if ( empty( $plan_id ) ) {
+            $plan_id = 'none';
+        }
+        $map_show    = get_post_meta( $plan_id, 'map_show', true );
+        $social_show = get_post_meta( $plan_id, 'listingproc_social', true );
+        $location_show = get_post_meta( $plan_id, 'listingproc_location', true );
+        $contact_show = get_post_meta( $plan_id, 'contact_show', true );
+        $website_show = get_post_meta( $plan_id, 'listingproc_website', true );
+        $hours_show   = get_post_meta( $plan_id, 'listingproc_bhours', true );
+        if ( 'none' === $plan_id ) {
+            $map_show = $social_show = $location_show = $contact_show = $website_show = $hours_show = 'true';
+        }
+
+        $address   = lp_onepage_meta( 'gAddress' );
+        $phone     = lp_onepage_meta( 'phone' );
+        $website   = lp_onepage_meta( 'website' );
+        $email     = lp_onepage_meta( 'email' );
+        $whatsapp  = lp_onepage_meta( 'whatsapp' );
+        $latitude  = lp_onepage_meta( 'latitude' );
+        $longitude = lp_onepage_meta( 'longitude' );
+        $hours     = lp_onepage_meta( 'business_hours' );
+
+        $facebook  = lp_onepage_meta( 'facebook' );
+        $twitter   = lp_onepage_meta( 'twitter' );
+        $linkedin  = lp_onepage_meta( 'linkedin' );
+        $youtube   = lp_onepage_meta( 'youtube' );
+        $instagram = lp_onepage_meta( 'instagram' );
+
+        $locations  = get_the_terms( get_the_ID(), 'location' );
+        $categories = get_the_terms( get_the_ID(), 'listing-category' );
+        $price_html = function_exists( 'listingpro_price_dynesty' ) ? listingpro_price_dynesty( get_the_ID() ) : '';
+
+        $lp_title    = get_the_title();
+        $tagline_text = lp_onepage_meta( 'tagline_text' );
+        if ( empty( $tagline_text ) ) {
+            $tagline_text = '&nbsp;';
+        }
+        $claimed_section = lp_onepage_meta( 'claimed_section' );
+        $claimed_position = '';
+        $title_len = strlen( $lp_title );
+        if ( $title_len > 34 && $title_len < 43 ) {
+            $claimed_position = 'position-static';
+        }
+        $claim = '';
+        if ( 'claimed' === $claimed_section ) {
+            $claim = '<span class="claimed ' . $claimed_position . '"><i class="fa fa-check"></i> ' . esc_html__( 'Claimed', 'listingpro' ) . '</span>';
+        }
+
+        $NumberRating = function_exists( 'listingpro_ratings_numbers' ) ? listingpro_ratings_numbers( get_the_ID() ) : 0;
+        $rating       = get_post_meta( get_the_ID(), 'listing_rate', true );
+        $rating       = $rating ? $rating : 0;
+        $rating_num_bg = '';
+        $rating_num_clr = '';
+        if ( $rating < 2 ) {
+            $rating_num_bg = 'num-level1';
+            $rating_num_clr = 'level1';
+        } elseif ( $rating < 3 ) {
+            $rating_num_bg = 'num-level2';
+            $rating_num_clr = 'level2';
+        } elseif ( $rating < 4 ) {
+            $rating_num_bg = 'num-level3';
+            $rating_num_clr = 'level3';
+        } else {
+            $rating_num_bg = 'num-level4';
+            $rating_num_clr = 'level4';
+        }
+        $resurva_url = get_post_meta( get_the_ID(), 'resurva_url', true );
+
+        foreach ( $layout_general as $section_key ) {
+            switch ( $section_key ) {
+                case 'lp_content_section':
+                    if ( ! empty( $description ) ) {
+                        $menu_items['about'] = __( 'Hakkımızda', 'listingpro' );
+                    }
+                    break;
+                case 'lp_services_section':
+                    if ( ! empty( $services ) ) {
+                        $menu_items['services'] = __( 'Hizmetler', 'listingpro' );
+                    }
+                    break;
+                case 'lp_gallery_section':
+                    if ( ! empty( $gallery_ids ) ) {
+                        $menu_items['gallery'] = __( 'Resim', 'listingpro' );
+                    }
+                    break;
+                case 'lp_video_section':
+                    if ( ! empty( $video ) ) {
+                        $menu_items['video'] = __( 'Video', 'listingpro' );
+                    }
+                    break;
+            }
+        }
+
+        if ( 'true' === $map_show && ! empty( $latitude ) && ! empty( $longitude ) ) {
+            $menu_items['map'] = __( 'Harita', 'listingpro' );
+        }
+        if ( 'true' === $hours_show && ! empty( $hours ) ) {
+            $menu_items['hours'] = __( 'Çalışma Saatleri', 'listingpro' );
+        }
+        $menu_items['contact'] = __( 'İletişim', 'listingpro' );
+
+        $b_logo       = $listingpro_options['business_logo_switch'];
+        $allow_logo   = isset( $listingpro_options['listingpro_allow_logo_styles_switch'] ) ? $listingpro_options['listingpro_allow_logo_styles_switch'] : '';
+        $business_logo_url = '';
+        if ( $b_logo && 'yes' === $allow_logo ) {
+            $b_logo_default    = $listingpro_options['business_logo_default']['url'];
+            $business_logo     = lp_onepage_meta_by_id( 'business_logo', get_the_ID() );
+            $business_logo_url = ! empty( $business_logo ) ? $business_logo : $b_logo_default;
+        }
+        ?>
+        <style>
+        .lp-onepage-header{display:flex;align-items:center;justify-content:space-between;gap:30px;margin-bottom:40px;}
+        .lp-onepage-logo img{max-height:80px;width:auto;}
+        .lp-onepage-nav ul{list-style:none;margin:0;padding:0;display:flex;gap:20px;}
+        .lp-onepage-nav a{text-decoration:none;color:inherit;font-weight:600;}
+        .lp-section{margin-bottom:60px;}
+        .lp-section-title{margin:0 0 20px;font-size:28px;font-weight:700;}
+        .lp-gallery-grid{display:flex;flex-wrap:wrap;gap:15px;}
+        .lp-gallery-grid img{max-width:100%;height:auto;border-radius:4px;}
+        #singlepostmap{width:100%;height:300px;border-radius:4px;}
+        .lp-contact-list{list-style:none;margin:0;padding:0;}
+        .lp-contact-list li{margin-bottom:8px;}
+        .lp-social-list{list-style:none;margin:20px 0 0;padding:0;display:flex;gap:10px;}
+        .lp-social-list a{text-decoration:none;font-size:20px;}
+        .lp-listing-tagline{margin-top:10px;font-size:18px;color:#555;}
+        .lp-home-meta{list-style:none;margin:10px 0 0;padding:0;display:flex;gap:15px;font-size:14px;color:#777;}
+        .lp-home-meta li{display:flex;align-items:center;gap:5px;}
+        </style>
+        <div class="lp-onepage-wrapper">
+        <header class="lp-onepage-header">
+            <?php if ( ! empty( $business_logo_url ) ) : ?>
+                <div class="lp-onepage-logo"><img src="<?php echo esc_attr( $business_logo_url ); ?>" alt="<?php esc_attr_e( 'Listing Logo', 'listingpro' ); ?>"></div>
+            <?php else : ?>
+                <div class="lp-onepage-logo"><?php the_post_thumbnail( 'medium' ); ?></div>
+            <?php endif; ?>
+            <nav class="lp-onepage-nav">
+                <ul>
+                    <?php foreach ( $menu_items as $slug => $label ) : ?>
+                        <li><a href="#<?php echo esc_attr( $slug ); ?>"><?php echo esc_html( $label ); ?></a></li>
+                    <?php endforeach; ?>
+                </ul>
+            </nav>
+        </header>
+
+        <?php
+        $header_bg = isset( $listingpro_options['lp_detail_page_styles4_bg'] ) ? $listingpro_options['lp_detail_page_styles4_bg'] : array();
+        ?>
+        <section id="home" class="lp-section lp-section-home">
+            <div class="lp-listing-top-title-header" <?php if ( ! empty( $header_bg['url'] ) ) : ?>style="background-image:url(<?php echo esc_url( $header_bg['url'] ); ?>)"<?php endif; ?>>
+                <div class="lp-header-overlay"></div>
+                <div class="container pos-relative">
+                    <div class="row">
+                        <div class="col-md-8">
+                            <?php
+                            include locate_template( 'templates/single-list/listing-details-style4/content/title-bar.php' );
+                            get_template_part( 'templates/single-list/listing-details-style4/content/gallery' );
+                            ?>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <?php foreach ( $layout_general as $section_key ) {
+            switch ( $section_key ) {
+                case 'lp_content_section':
+                    if ( isset( $menu_items['about'] ) ) {
+                        ?>
+                        <section id="about" class="lp-section lp-section-about">
+                            <h2 class="lp-section-title"><?php echo esc_html( $menu_items['about'] ); ?></h2>
+                            <?php echo apply_filters( 'the_content', $description ); ?>
+                        </section>
+                        <?php
+                    }
+                    break;
+                case 'lp_services_section':
+                    if ( isset( $menu_items['services'] ) ) {
+                        ?>
+                        <section id="services" class="lp-section lp-section-services">
+                            <h2 class="lp-section-title"><?php echo esc_html( $menu_items['services'] ); ?></h2>
+                            <ul>
+                            <?php foreach ( $services as $term ) : ?>
+                                <li><?php echo esc_html( $term->name ); ?></li>
+                            <?php endforeach; ?>
+                            </ul>
+                        </section>
+                        <?php
+                    }
+                    break;
+                case 'lp_gallery_section':
+                    if ( isset( $menu_items['gallery'] ) ) {
+                        ?>
+                        <section id="gallery" class="lp-section lp-section-gallery">
+                            <h2 class="lp-section-title"><?php echo esc_html( $menu_items['gallery'] ); ?></h2>
+                            <div class="lp-gallery-grid">
+                            <?php foreach ( $gallery_ids as $image_id ) { echo wp_get_attachment_image( $image_id, 'large' ); } ?>
+                            </div>
+                        </section>
+                        <?php
+                    }
+                    break;
+                case 'lp_video_section':
+                    if ( isset( $menu_items['video'] ) ) {
+                        ?>
+                        <section id="video" class="lp-section lp-section-video">
+                            <h2 class="lp-section-title"><?php echo esc_html( $menu_items['video'] ); ?></h2>
+                            <?php echo apply_filters( 'the_content', (string) $video ); ?>
+                        </section>
+                        <?php
+                    }
+                    break;
+            }
+        }
+        ?>
+
+        <?php if ( isset( $menu_items['map'] ) ) :
+            $lp_map_pin = $listingpro_options['lp_map_pin']['url']; ?>
+            <section id="map" class="lp-section lp-section-map">
+                <h2 class="lp-section-title"><?php echo esc_html( $menu_items['map'] ); ?></h2>
+                <div id="singlepostmap" class="singlemap" data-lat="<?php echo esc_attr( $latitude ); ?>" data-lan="<?php echo esc_attr( $longitude ); ?>" data-pinicon="<?php echo esc_attr( $lp_map_pin ); ?>"></div>
+            </section>
+        <?php endif; ?>
+
+        <?php if ( isset( $menu_items['hours'] ) ) : ?>
+            <section id="hours" class="lp-section lp-section-hours">
+                <h2 class="lp-section-title"><?php echo esc_html( $menu_items['hours'] ); ?></h2>
+                <?php get_template_part( 'include/timings' ); ?>
+            </section>
+        <?php endif; ?>
+
+        <section id="contact" class="lp-section lp-section-contact">
+            <h2 class="lp-section-title"><?php echo esc_html( $menu_items['contact'] ); ?></h2>
+            <ul class="lp-contact-list">
+                <?php if ( 'true' === $location_show && ! empty( $address ) ) : ?>
+                    <li class="lp-contact-address"><?php echo esc_html( $address ); ?></li>
+                <?php endif; ?>
+                <?php if ( 'true' === $contact_show && ! empty( $email ) ) : ?>
+                    <li class="lp-contact-email"><a href="mailto:<?php echo esc_attr( $email ); ?>"><?php echo esc_html( $email ); ?></a></li>
+                <?php endif; ?>
+                <?php if ( 'true' === $contact_show && ! empty( $phone ) ) : ?>
+                    <li class="lp-contact-phone"><?php echo esc_html( $phone ); ?></li>
+                <?php endif; ?>
+                <?php if ( 'true' === $contact_show && ! empty( $whatsapp ) ) :
+                    $wa_link = 'https://api.whatsapp.com/send?phone=' . $whatsapp; ?>
+                    <li class="lp-contact-whatsapp"><a href="<?php echo esc_url( $wa_link ); ?>" target="_blank"><?php echo esc_html( $whatsapp ); ?></a></li>
+                <?php endif; ?>
+                <?php if ( 'true' === $website_show && ! empty( $website ) ) : ?>
+                    <li class="lp-contact-website"><a href="<?php echo esc_url( $website ); ?>" target="_blank"><?php echo esc_html( $website ); ?></a></li>
+                <?php endif; ?>
+            </ul>
+            <?php if ( 'true' === $social_show && ( $facebook || $twitter || $linkedin || $youtube || $instagram ) ) : ?>
+                <ul class="lp-social-list">
+                    <?php if ( ! empty( $facebook ) ) : ?><li><a href="<?php echo esc_url( $facebook ); ?>" target="_blank"><i class="fa-brands fa-square-facebook"></i></a></li><?php endif; ?>
+                    <?php if ( ! empty( $twitter ) ) : ?><li><a href="<?php echo esc_url( $twitter ); ?>" target="_blank"><i class="fa-brands fa-square-x-twitter"></i></a></li><?php endif; ?>
+                    <?php if ( ! empty( $linkedin ) ) : ?><li><a href="<?php echo esc_url( $linkedin ); ?>" target="_blank"><i class="fa-brands fa-linkedin"></i></a></li><?php endif; ?>
+                    <?php if ( ! empty( $youtube ) ) : ?><li><a href="<?php echo esc_url( $youtube ); ?>" target="_blank"><i class="fa-brands fa-youtube"></i></a></li><?php endif; ?>
+                    <?php if ( ! empty( $instagram ) ) : ?><li><a href="<?php echo esc_url( $instagram ); ?>" target="_blank"><i class="fa-brands fa-square-instagram"></i></a></li><?php endif; ?>
+                </ul>
+            <?php endif; ?>
+        </section>
+
+        <script>
+        jQuery(function($){
+            $('.lp-onepage-nav a').on('click', function(e){
+                e.preventDefault();
+                var target = this.hash;
+                $('html, body').animate({
+                    scrollTop: $(target).offset().top
+                }, 500);
+            });
+        });
+        </script>
+        </div><!-- /.lp-onepage-wrapper -->
+        <?php
+    }
+}
+?>

--- a/templates/listing-onepage.php
+++ b/templates/listing-onepage.php
@@ -38,14 +38,11 @@ if ( have_posts() ) {
                 }
 
                 ob_start();
-                $include_result = include $template_path;
-                $html_output    = ob_get_clean();
 
-                if ( false === $include_result ) {
-                    return '';
-                }
+                global $post;
+                include $template_path;
 
-                return trim( $html_output );
+                return trim( ob_get_clean() );
             }
         }
 
@@ -679,7 +676,6 @@ if ( have_posts() ) {
         <?php foreach ( $sections_markup as $section_html ) : ?>
             <?php echo $section_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
         <?php endforeach; ?>
-        ?>
 
         <?php if ( $has_map ) :
             $lp_map_pin = $listingpro_options['lp_map_pin']['url']; ?>

--- a/templates/listing-onepage.php
+++ b/templates/listing-onepage.php
@@ -202,6 +202,12 @@ if ( have_posts() ) {
         if ( $has_reviews ) {
             $menu_items['reviews'] = __( 'Yorumlar', 'listingpro' );
         }
+        if ( $has_map ) {
+            $menu_items['map'] = __( 'Harita', 'listingpro' );
+        }
+        if ( $has_hours ) {
+            $menu_items['hours'] = __( 'Çalışma Saatleri', 'listingpro' );
+        }
         $menu_items['contact'] = __( 'İletişim', 'listingpro' );
 
         $b_logo       = $listingpro_options['business_logo_switch'];

--- a/templates/listing-onepage.php
+++ b/templates/listing-onepage.php
@@ -757,7 +757,11 @@ if ( have_posts() ) {
         .lp-social-list{list-style:none;margin:20px 0 0;padding:0;display:flex;gap:10px;justify-content:center;}
         .lp-social-list a{text-decoration:none;font-size:20px;}
         .lp-listing-tagline{margin-top:10px;font-size:18px;color:#555;}
-        .lp-whatsapp-float{position:fixed;right:20px;bottom:20px;width:50px;height:50px;border-radius:50%;background:#25d366;color:#fff;display:flex;align-items:center;justify-content:center;font-size:24px;z-index:1000;}
+        .lp-phone-float,.lp-whatsapp-float{position:fixed;right:20px;width:50px;height:50px;border-radius:50%;color:#fff;display:flex;align-items:center;justify-content:center;font-size:22px;z-index:1000;box-shadow:0 10px 24px rgba(15,23,42,0.2);}
+        .lp-phone-float{bottom:80px;background:#ef4444;}
+        .lp-phone-float:hover{background:#dc2626;color:#fff;}
+        .lp-whatsapp-float{bottom:20px;background:#25d366;}
+        .lp-whatsapp-float:hover{background:#1ebe5d;color:#fff;}
         .lp-hero-banner{position:relative;min-height:360px;background-size:cover;background-position:center center;border-radius:12px;margin:20px auto;max-width:1170px;overflow:hidden;}
         .lp-hero-banner .lp-header-overlay{position:absolute;top:0;left:0;width:100%;height:100%;background:rgba(15,23,42,0.25);}
         .lp-quick-actions{max-width:1170px;margin:20px auto 0;display:flex;flex-wrap:wrap;gap:12px;justify-content:center;}
@@ -903,6 +907,9 @@ if ( have_posts() ) {
                 <?php get_template_part( 'templates/single-list/listing-details-style3/sidebar/lead-form' ); ?>
             </div>
         </section>
+        <?php if ( ! empty( $phone ) ) : ?>
+            <a class="lp-phone-float" href="tel:<?php echo esc_attr( $phone ); ?>"><i class="fa fa-phone"></i></a>
+        <?php endif; ?>
         <?php if ( ! empty( $wa_link ) ) : ?>
             <a class="lp-whatsapp-float" href="<?php echo esc_url( $wa_link ); ?>" target="_blank"><i class="fa fa-whatsapp"></i></a>
         <?php endif; ?>

--- a/templates/listing-onepage.php
+++ b/templates/listing-onepage.php
@@ -585,6 +585,21 @@ if ( have_posts() ) {
             $initial = function_exists( 'mb_substr' ) ? mb_substr( $lp_title, 0, 1 ) : substr( $lp_title, 0, 1 );
             $logo_html = '<span class="lp-logo-initial">' . esc_html( strtoupper( $initial ) ) . '</span>';
         }
+        $header_bg = isset( $listingpro_options['lp_detail_page_styles4_bg'] ) ? $listingpro_options['lp_detail_page_styles4_bg'] : array();
+        $hero_image_url = '';
+        $featured_id    = get_post_thumbnail_id( get_the_ID() );
+        if ( $featured_id ) {
+            $hero_image_url = wp_get_attachment_image_url( $featured_id, 'full' );
+        }
+        if ( empty( $hero_image_url ) && ! empty( $gallery_ids ) ) {
+            $first_gallery = reset( $gallery_ids );
+            if ( $first_gallery ) {
+                $hero_image_url = wp_get_attachment_image_url( $first_gallery, 'full' );
+            }
+        }
+        if ( empty( $hero_image_url ) && ! empty( $header_bg['url'] ) ) {
+            $hero_image_url = $header_bg['url'];
+        }
         ?>
         <style>
         .lp-onepage-header{position:sticky;top:0;background:#fff;z-index:999;border-bottom:1px solid #eee;}
@@ -620,6 +635,8 @@ if ( have_posts() ) {
         .lp-home-meta{list-style:none;margin:10px 0 0;padding:0;display:flex;gap:15px;font-size:14px;color:#777;justify-content:center;}
         .lp-home-meta li{display:flex;align-items:center;gap:5px;}
         .lp-whatsapp-float{position:fixed;right:20px;bottom:20px;width:50px;height:50px;border-radius:50%;background:#25d366;color:#fff;display:flex;align-items:center;justify-content:center;font-size:24px;z-index:1000;}
+        .lp-hero-banner{position:relative;min-height:360px;background-size:cover;background-position:center center;border-radius:12px;margin:20px auto;max-width:1170px;overflow:hidden;}
+        .lp-hero-banner .lp-header-overlay{position:absolute;top:0;left:0;width:100%;height:100%;background:rgba(15,23,42,0.25);}
         </style>
         <div class="lp-onepage-wrapper">
         <header class="lp-onepage-header">
@@ -644,22 +661,9 @@ if ( have_posts() ) {
             </div>
         </header>
 
-        <?php
-        $header_bg = isset( $listingpro_options['lp_detail_page_styles4_bg'] ) ? $listingpro_options['lp_detail_page_styles4_bg'] : array();
-        ?>
         <section id="home" class="lp-section lp-section-home">
-            <div class="lp-listing-top-title-header" <?php if ( ! empty( $header_bg['url'] ) ) : ?>style="background-image:url(<?php echo esc_url( $header_bg['url'] ); ?>)"<?php endif; ?>>
+            <div class="lp-hero-banner" <?php if ( ! empty( $hero_image_url ) ) : ?>style="background-image:url(<?php echo esc_url( $hero_image_url ); ?>)"<?php endif; ?>>
                 <div class="lp-header-overlay"></div>
-                <div class="container pos-relative">
-                    <div class="row">
-                        <div class="col-md-8">
-                            <?php
-                            include locate_template( 'templates/single-list/listing-details-style4/content/title-bar.php' );
-                            get_template_part( 'templates/single-list/listing-details-style4/content/gallery' );
-                            ?>
-                        </div>
-                    </div>
-                </div>
             </div>
         </section>
         <?php if ( ! empty( $locations ) || ! empty( $categories ) || ! empty( $price_html ) ) : ?>

--- a/templates/listing-onepage.php
+++ b/templates/listing-onepage.php
@@ -68,8 +68,9 @@ if ( have_posts() ) {
         $faqs_show     = get_post_meta( $plan_id, 'listingproc_faq', true );
         $price_show    = get_post_meta( $plan_id, 'listingproc_price', true );
         $tags_show     = get_post_meta( $plan_id, 'listingproc_tag_key', true );
+        $gallery_show  = get_post_meta( $plan_id, 'gallery_show', true );
         if ( 'none' === $plan_id ) {
-            $map_show = $social_show = $location_show = $contact_show = $website_show = $hours_show = $faqs_show = $price_show = $tags_show = 'true';
+            $map_show = $social_show = $location_show = $contact_show = $website_show = $hours_show = $faqs_show = $price_show = $tags_show = $gallery_show = 'true';
         }
 
         $address   = lp_onepage_meta( 'gAddress' );
@@ -99,9 +100,7 @@ if ( have_posts() ) {
         $categories = get_the_terms( get_the_ID(), 'listing-category' );
         $price_html = '';
         if ( function_exists( 'listingpro_price_dynesty' ) ) {
-            ob_start();
-            listingpro_price_dynesty( get_the_ID() );
-            $price_html = ob_get_clean();
+            $price_html = listingpro_price_dynesty( get_the_ID() );
         }
 
         $lp_title    = get_the_title();
@@ -166,7 +165,7 @@ if ( have_posts() ) {
                     }
                     break;
                 case 'lp_gallery_section':
-                    if ( ! empty( $gallery_ids ) ) {
+                    if ( lp_onepage_on( $gallery_show ) && ! empty( $gallery_ids ) ) {
                         $menu_items['gallery'] = __( 'Resim', 'listingpro' );
                     }
                     break;
@@ -249,9 +248,10 @@ if ( have_posts() ) {
         .lp-section{padding:60px 0;}
         .lp-section .container{max-width:1170px;margin:0 auto;}
         .lp-section-title{margin:0 0 30px;font-size:28px;font-weight:700;text-align:center;}
-        .lp-gallery-grid{display:flex;flex-wrap:wrap;gap:15px;}
-        .lp-gallery-item{flex:1 1 calc(33.333% - 10px);}
-        .lp-gallery-grid img{width:100%;height:auto;border-radius:4px;}
+        .lp-onepage-gallery-slider{position:relative;}
+        .lp-onepage-gallery-slider .listing-slide2,
+        .lp-onepage-gallery-slider .listing-slide{margin:0;}
+        .lp-onepage-gallery-slider .slide img{width:100%;height:auto;border-radius:4px;}
         .lp-video-wrapper{position:relative;padding-bottom:73.5%;height:0;overflow:hidden;}
         .lp-video-wrapper iframe{position:absolute;top:0;left:0;width:100%;height:100%;}
         #singlepostmap{width:100%;height:300px;border-radius:4px;}
@@ -323,7 +323,7 @@ if ( have_posts() ) {
                         <li><i class="fa fa-folder-open"></i><?php echo esc_html( $categories[0]->name ); ?></li>
                     <?php endif; ?>
                     <?php if ( ! empty( $price_html ) ) : ?>
-                        <li><?php echo $price_html; ?></li>
+                        <li><?php echo wp_kses_post( $price_html ); ?></li>
                     <?php endif; ?>
                 </ul>
             </div>
@@ -366,14 +366,46 @@ if ( have_posts() ) {
                         <section id="gallery" class="lp-section lp-section-gallery">
                             <div class="container">
                                 <h2 class="lp-section-title"><?php echo esc_html( $menu_items['gallery'] ); ?></h2>
-                                <div class="lp-gallery-grid">
-                                <?php foreach ( $gallery_ids as $image_id ) :
-                                    $img_full = wp_get_attachment_image_src( $image_id, 'full' );
-                                    if ( $img_full ) : ?>
-                                        <div class="lp-gallery-item"><img src="<?php echo esc_url( $img_full[0] ); ?>" alt="<?php echo esc_attr( $lp_title ); ?>"></div>
-                                    <?php endif;
-                                endforeach; ?>
-                                </div>
+                                <?php
+                                $lp_detail_slider_styles = isset( $listingpro_options['lp_detail_slider_styles'] ) ? $listingpro_options['lp_detail_slider_styles'] : 'style1';
+                                $imgIDs                 = $gallery_ids;
+                                $numImages              = $num_gallery;
+                                if ( ! empty( $imgIDs ) && $numImages >= 1 ) :
+                                    if ( file_exists( THEME_PATH . '/include/aq_resizer.php' ) ) {
+                                        require_once THEME_PATH . '/include/aq_resizer.php';
+                                    }
+                                    ?>
+                                    <div class="pos-relative lp-onepage-gallery-slider">
+                                        <div class="spinner">
+                                            <div class="double-bounce1"></div>
+                                            <div class="double-bounce2"></div>
+                                        </div>
+                                        <div class="single-page-slider-container <?php echo esc_attr( $lp_detail_slider_styles ); ?>">
+                                            <div class="row">
+                                                <div class="col-md-12">
+                                                    <div class="<?php echo ( 'style2' === $lp_detail_slider_styles ) ? 'listing-slide' : 'listing-slide2'; ?> img_<?php echo esc_attr( $numImages ); ?>" data-images-num="<?php echo esc_attr( $numImages ); ?>">
+                                                        <?php
+                                                        foreach ( $imgIDs as $imgID ) {
+                                                            $img_url  = wp_get_attachment_image_src( $imgID, 'full' );
+                                                            $img_full = $img_url ? $img_url[0] : '';
+                                                            $img_src  = $img_full;
+                                                            if ( ! empty( $img_full ) && function_exists( 'aq_resize' ) ) {
+                                                                $resized = aq_resize( $img_full, 770, 566, true, true, true );
+                                                                if ( ! empty( $resized ) ) {
+                                                                    $img_src = $resized;
+                                                                }
+                                                            }
+                                                            if ( ! empty( $img_full ) ) {
+                                                                echo '<div class="slide"><a href="' . esc_url( $img_full ) . '" rel="prettyPhoto[gallery1]"><img src="' . esc_url( $img_src ) . '" alt="' . esc_attr( $lp_title ) . '" /></a></div>';
+                                                            }
+                                                        }
+                                                        ?>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                <?php endif; ?>
                             </div>
                         </section>
                         <?php
@@ -582,10 +614,17 @@ if ( have_posts() ) {
                         <li class="lp-contact-website"><i class="fa fa-globe"></i><a href="<?php echo esc_url( $website ); ?>" target="_blank"><?php echo esc_html( $website ); ?></a></li>
                     <?php endif; ?>
                     <?php if ( lp_onepage_on( $price_show ) && ! empty( $price_html ) ) : ?>
-                        <li class="lp-contact-price"><?php echo $price_html; ?></li>
+                        <li class="lp-contact-price"><?php echo wp_kses_post( $price_html ); ?></li>
                     <?php endif; ?>
-                    <?php if ( lp_onepage_on( $tags_show ) && ! empty( $tags_terms ) ) : ?>
-                        <li class="lp-contact-tags"><i class="fa fa-tags"></i><?php echo esc_html( join( ', ', wp_list_pluck( $tags_terms, 'name' ) ) ); ?></li>
+                    <?php if ( lp_onepage_on( $tags_show ) && ! empty( $tags_terms ) ) :
+                        $tag_names = array();
+                        foreach ( $tags_terms as $tag_term ) {
+                            $tag_names[] = $tag_term->name;
+                        }
+                        $tag_names = array_filter( $tag_names );
+                        if ( ! empty( $tag_names ) ) : ?>
+                        <li class="lp-contact-tags"><i class="fa fa-tags"></i><?php echo esc_html( implode( ', ', $tag_names ) ); ?></li>
+                        <?php endif; ?>
                     <?php endif; ?>
                 </ul>
                 <?php if ( lp_onepage_on( $social_show ) && ( $facebook || $twitter || $linkedin || $youtube || $instagram ) ) : ?>

--- a/templates/listing-onepage.php
+++ b/templates/listing-onepage.php
@@ -397,6 +397,20 @@ if ( have_posts() ) {
                 continue;
             }
             switch ( $section_key ) {
+                case 'lp_additional_section':
+                    if ( function_exists( 'listing_all_extra_fields' ) ) {
+                        $additional_html = listing_all_extra_fields( get_the_ID() );
+                        if ( ! empty( $additional_html ) ) {
+                            ?>
+                            <section id="additional" class="lp-section lp-section-additional">
+                                <div class="container">
+                                    <?php echo $additional_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                                </div>
+                            </section>
+                            <?php
+                        }
+                    }
+                    break;
                 case 'lp_faqs_section':
                     if ( lp_onepage_on( $faqs_show ) && $has_faq ) {
                         ?>
@@ -419,6 +433,24 @@ if ( have_posts() ) {
                             </div>
                         </section>
                         <?php
+                    }
+                    break;
+                case 'lp_offers_section':
+                    $post_author_id      = get_post_field( 'post_author', get_the_ID() );
+                    $discount_displayin = get_user_meta( $post_author_id, 'discount_display_area', true );
+                    if ( 'content' === $discount_displayin || empty( $discount_displayin ) ) {
+                        ob_start();
+                        get_template_part( 'templates/single-list/listing-details-style6/content/list-offer-deals-discount' );
+                        $offers_html = trim( ob_get_clean() );
+                        if ( '' !== trim( wp_strip_all_tags( $offers_html ) ) ) {
+                            ?>
+                            <section id="offers" class="lp-section lp-section-offers">
+                                <div class="container">
+                                    <?php echo $offers_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                                </div>
+                            </section>
+                            <?php
+                        }
                     }
                     break;
                 case 'lp_menu_section':
@@ -450,6 +482,26 @@ if ( have_posts() ) {
                         <?php
                     }
                     break;
+                case 'lp_event_section':
+                    $post_author_id = get_post_field( 'post_author', get_the_ID() );
+                    $event_displayin = get_user_meta( $post_author_id, 'event_display_area', true );
+                    if ( 'content' === $event_displayin || empty( $event_displayin ) ) {
+                        $GLOBALS['event_grid_call'] = 'content_area';
+                        ob_start();
+                        get_template_part( 'templates/single-list/event' );
+                        $events_html = trim( ob_get_clean() );
+                        unset( $GLOBALS['event_grid_call'] );
+                        if ( '' !== trim( wp_strip_all_tags( $events_html ) ) ) {
+                            ?>
+                            <section id="events" class="lp-section lp-section-events">
+                                <div class="container">
+                                    <?php echo $events_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                                </div>
+                            </section>
+                            <?php
+                        }
+                    }
+                    break;
                 case 'lp_quicks_section':
                     ?>
                     <section id="quicks" class="lp-section lp-section-quicks">
@@ -458,6 +510,20 @@ if ( have_posts() ) {
                         </div>
                     </section>
                     <?php
+                    break;
+                case 'lp_reviewform_section':
+                    ob_start();
+                    get_template_part( 'templates/single-list/listing-details-style6/content/reviewform' );
+                    $review_form_html = trim( ob_get_clean() );
+                    if ( '' !== trim( wp_strip_all_tags( $review_form_html ) ) ) {
+                        ?>
+                        <section id="review-form" class="lp-section lp-section-reviewform">
+                            <div class="container">
+                                <?php echo $review_form_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                            </div>
+                        </section>
+                        <?php
+                    }
                     break;
             }
         }

--- a/templates/listing-onepage.php
+++ b/templates/listing-onepage.php
@@ -199,7 +199,7 @@ if ( have_posts() ) {
         $enabled_sections = array_flip( $layout_general );
 
         $has_map   = lp_onepage_on( $map_show ) && ! empty( $latitude ) && ! empty( $longitude );
-        $has_hours = lp_onepage_on( $hours_show ) && ( is_array( $hours ) ? ! empty( array_filter( $hours ) ) : ! empty( $hours ) );
+        $has_hours = is_array( $hours ) ? ! empty( array_filter( $hours ) ) : ! empty( $hours );
 
         $sections_markup = array();
         $menu_items      = array( 'home' => __( 'Anasayfa', 'listingpro' ) );
@@ -677,6 +677,10 @@ if ( have_posts() ) {
         .lp-whatsapp-float{position:fixed;right:20px;bottom:20px;width:50px;height:50px;border-radius:50%;background:#25d366;color:#fff;display:flex;align-items:center;justify-content:center;font-size:24px;z-index:1000;}
         .lp-hero-banner{position:relative;min-height:360px;background-size:cover;background-position:center center;border-radius:12px;margin:20px auto;max-width:1170px;overflow:hidden;}
         .lp-hero-banner .lp-header-overlay{position:absolute;top:0;left:0;width:100%;height:100%;background:rgba(15,23,42,0.25);}
+        .lp-quick-actions{max-width:1170px;margin:20px auto 0;display:flex;flex-wrap:wrap;gap:12px;justify-content:center;}
+        .lp-quick-actions a{display:flex;align-items:center;gap:8px;padding:10px 18px;border-radius:999px;background:#f1f5f9;color:#1f2933;font-weight:600;text-decoration:none;transition:all .2s ease;box-shadow:0 6px 18px rgba(15,23,42,0.08);}
+        .lp-quick-actions a:hover{background:#e2e8f0;color:#005f99;box-shadow:0 10px 24px rgba(15,23,42,0.12);}
+        .lp-quick-actions i{font-size:16px;}
         </style>
         <div class="lp-onepage-wrapper">
         <header class="lp-onepage-header">
@@ -706,6 +710,25 @@ if ( have_posts() ) {
                 <div class="lp-header-overlay"></div>
             </div>
         </section>
+        <?php if ( ! empty( $phone ) || ! empty( $website ) || ! empty( $whatsapp ) || $has_hours || ( $has_map && ! empty( $latitude ) && ! empty( $longitude ) ) ) : ?>
+            <div class="lp-quick-actions">
+                <?php if ( ! empty( $phone ) ) : ?>
+                    <a href="tel:<?php echo esc_attr( $phone ); ?>"><i class="fa fa-phone"></i><?php echo esc_html( $phone ); ?></a>
+                <?php endif; ?>
+                <?php if ( ! empty( $whatsapp ) ) : ?>
+                    <a href="<?php echo esc_url( $wa_link ); ?>" target="_blank" rel="noopener"><i class="fa fa-whatsapp"></i><?php echo esc_html__( 'WhatsApp', 'listingpro' ); ?></a>
+                <?php endif; ?>
+                <?php if ( ! empty( $website ) ) : ?>
+                    <a href="<?php echo esc_url( $website ); ?>" target="_blank" rel="noopener"><i class="fa fa-globe"></i><?php echo esc_html__( 'Web Sitesi', 'listingpro' ); ?></a>
+                <?php endif; ?>
+                <?php if ( $has_hours ) : ?>
+                    <a href="#hours"><i class="fa fa-clock-o"></i><?php echo esc_html__( 'Çalışma Saatleri', 'listingpro' ); ?></a>
+                <?php endif; ?>
+                <?php if ( $has_map && ! empty( $latitude ) && ! empty( $longitude ) ) : ?>
+                    <a href="https://www.google.com/maps/search/?api=1&amp;query=<?php echo esc_attr( $latitude ); ?>,<?php echo esc_attr( $longitude ); ?>" target="_blank" rel="noopener"><i class="fa fa-map-marker"></i><?php echo esc_html__( 'Harita', 'listingpro' ); ?></a>
+                <?php endif; ?>
+            </div>
+        <?php endif; ?>
         <?php foreach ( $sections_markup as $section_html ) : ?>
             <?php echo $section_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
         <?php endforeach; ?>
@@ -751,7 +774,7 @@ if ( have_posts() ) {
                     <?php if ( ! empty( $whatsapp ) ) : ?>
                         <li class="lp-contact-whatsapp"><i class="fa fa-whatsapp"></i><a href="<?php echo esc_url( $wa_link ); ?>" target="_blank"><?php echo esc_html( $whatsapp ); ?></a></li>
                     <?php endif; ?>
-                    <?php if ( lp_onepage_on( $website_show ) && ! empty( $website ) ) : ?>
+                    <?php if ( ! empty( $website ) ) : ?>
                         <li class="lp-contact-website"><i class="fa fa-globe"></i><a href="<?php echo esc_url( $website ); ?>" target="_blank"><?php echo esc_html( $website ); ?></a></li>
                     <?php endif; ?>
                     <?php if ( lp_onepage_on( $price_show ) && ! empty( $price_html ) ) : ?>

--- a/templates/listing-onepage.php
+++ b/templates/listing-onepage.php
@@ -39,7 +39,16 @@ if ( have_posts() ) {
         if ( empty( $description ) ) {
             $description = get_post_field( 'post_content', get_the_ID() );
         }
-        $services = wp_get_post_terms( get_the_ID(), 'features' );
+        $services_terms = wp_get_post_terms( get_the_ID(), 'features' );
+        $service_names  = array();
+        if ( ! is_wp_error( $services_terms ) && ! empty( $services_terms ) ) {
+            foreach ( $services_terms as $service_term ) {
+                $name = trim( $service_term->name );
+                if ( '' !== $name ) {
+                    $service_names[] = $name;
+                }
+            }
+        }
         $gallery_ids = get_post_meta( get_the_ID(), 'gallery_image_ids', true );
         $gallery_ids = ! empty( $gallery_ids ) ? array_filter( explode( ',', $gallery_ids ) ) : array();
         $num_gallery = count( $gallery_ids );
@@ -86,6 +95,19 @@ if ( have_posts() ) {
         $longitude = lp_onepage_meta( 'longitude' );
         $hours     = lp_onepage_meta( 'business_hours' );
         $faqs      = lp_onepage_meta_by_id( 'faqs', get_the_ID() );
+        $has_faq   = false;
+        if ( is_array( $faqs ) ) {
+            if ( isset( $faqs['faq'] ) && is_array( $faqs['faq'] ) ) {
+                foreach ( $faqs['faq'] as $faq_item ) {
+                    $question = isset( $faq_item['lp_title'] ) ? trim( $faq_item['lp_title'] ) : '';
+                    $answer   = isset( $faq_item['lp_desc'] ) ? trim( $faq_item['lp_desc'] ) : '';
+                    if ( '' !== $question || '' !== $answer ) {
+                        $has_faq = true;
+                        break;
+                    }
+                }
+            }
+        }
         $email_switcher = function_exists( 'lp_theme_option' ) ? lp_theme_option( 'listingpro_email_display_switch' ) : 'yes';
 
         $tags_terms = get_the_terms( get_the_ID(), 'list-tags' );
@@ -160,7 +182,7 @@ if ( have_posts() ) {
                     }
                     break;
                 case 'lp_services_section':
-                    if ( ! empty( $services ) ) {
+                    if ( ! empty( $service_names ) ) {
                         $menu_items['services'] = __( 'Hizmetler', 'listingpro' );
                     }
                     break;
@@ -175,7 +197,7 @@ if ( have_posts() ) {
                     }
                     break;
                 case 'lp_faqs_section':
-                    if ( lp_onepage_on( $faqs_show ) && ! empty( $faqs ) && ! empty( $faqs['faq'][1] ) ) {
+                    if ( lp_onepage_on( $faqs_show ) && $has_faq ) {
                         $menu_items['faq'] = __( 'SSS', 'listingpro' );
                     }
                     break;
@@ -183,9 +205,6 @@ if ( have_posts() ) {
                     if ( $has_announcements ) {
                         $menu_items['announcements'] = __( 'Duyurular', 'listingpro' );
                     }
-                    break;
-                case 'lp_offers_section':
-                    $menu_items['offers'] = __( 'Fırsatlar', 'listingpro' );
                     break;
                 case 'lp_menu_section':
                     if ( $menuOption ) {
@@ -198,14 +217,8 @@ if ( have_posts() ) {
                 case 'lp_reviews_section':
                     $menu_items['reviews'] = __( 'Yorumlar', 'listingpro' );
                     break;
-                case 'lp_reviewform_section':
-                    $menu_items['reviewform'] = __( 'Yorum Yaz', 'listingpro' );
-                    break;
                 case 'lp_features_section':
                     $menu_items['features'] = __( 'Özellikler', 'listingpro' );
-                    break;
-                case 'lp_additional_section':
-                    $menu_items['additional'] = __( 'Ek Bilgiler', 'listingpro' );
                     break;
                 case 'lp_booking_section':
                     if ( $timekit || ! empty( $resurva_url ) || class_exists( 'Listingpro_bookings' ) ) {
@@ -231,16 +244,27 @@ if ( have_posts() ) {
         $allow_logo   = isset( $listingpro_options['listingpro_allow_logo_styles_switch'] ) ? $listingpro_options['listingpro_allow_logo_styles_switch'] : '';
         $business_logo_url = '';
         if ( $b_logo && 'yes' === $allow_logo ) {
-            $b_logo_default    = $listingpro_options['business_logo_default']['url'];
+            $b_logo_default    = isset( $listingpro_options['business_logo_default']['url'] ) ? $listingpro_options['business_logo_default']['url'] : '';
             $business_logo     = lp_onepage_meta_by_id( 'business_logo', get_the_ID() );
             $business_logo_url = ! empty( $business_logo ) ? $business_logo : $b_logo_default;
+        }
+        $logo_html = '';
+        if ( ! empty( $business_logo_url ) ) {
+            $logo_html = '<img src="' . esc_url( $business_logo_url ) . '" alt="' . esc_attr__( 'Listing Logo', 'listingpro' ) . '" />';
+        } elseif ( has_post_thumbnail() ) {
+            $logo_html = get_the_post_thumbnail( get_the_ID(), 'thumbnail' );
+        } else {
+            $initial = function_exists( 'mb_substr' ) ? mb_substr( $lp_title, 0, 1 ) : substr( $lp_title, 0, 1 );
+            $logo_html = '<span class="lp-logo-initial">' . esc_html( strtoupper( $initial ) ) . '</span>';
         }
         ?>
         <style>
         .lp-onepage-header{position:sticky;top:0;background:#fff;z-index:999;border-bottom:1px solid #eee;}
         .lp-onepage-header-inner{display:flex;align-items:center;justify-content:space-between;gap:30px;padding:15px 0;}
         .lp-onepage-brand{display:flex;align-items:center;gap:15px;}
-        .lp-onepage-logo img{width:60px;height:60px;border-radius:50%;object-fit:cover;}
+        .lp-onepage-logo{width:60px;height:60px;border-radius:50%;overflow:hidden;display:flex;align-items:center;justify-content:center;background:#eef2f7;font-weight:700;font-size:22px;color:#1f2933;text-transform:uppercase;}
+        .lp-onepage-logo img{width:100%;height:100%;object-fit:cover;}
+        .lp-logo-initial{display:block;width:100%;height:100%;line-height:60px;text-align:center;}
         .lp-onepage-name{font-weight:700;font-size:20px;}
         .lp-onepage-nav ul{list-style:none;margin:0;padding:0;display:flex;gap:30px;}
         .lp-onepage-nav a{text-decoration:none;color:#333;font-weight:600;display:flex;align-items:center;gap:5px;}
@@ -248,10 +272,12 @@ if ( have_posts() ) {
         .lp-section{padding:60px 0;}
         .lp-section .container{max-width:1170px;margin:0 auto;}
         .lp-section-title{margin:0 0 30px;font-size:28px;font-weight:700;text-align:center;}
-        .lp-onepage-gallery-slider{position:relative;}
-        .lp-onepage-gallery-slider .listing-slide2,
-        .lp-onepage-gallery-slider .listing-slide{margin:0;}
-        .lp-onepage-gallery-slider .slide img{width:100%;height:auto;border-radius:4px;}
+        .lp-services-list{list-style:none;margin:0 auto;max-width:700px;padding:0;display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:12px;text-align:center;}
+        .lp-services-list li{background:#f7f9fc;border-radius:10px;padding:12px 16px;font-weight:600;color:#1f2933;box-shadow:0 8px 20px rgba(15,23,42,0.06);}
+        .lp-gallery-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:20px;}
+        .lp-gallery-item{display:block;overflow:hidden;border-radius:8px;box-shadow:0 10px 25px rgba(15,23,42,0.08);transition:transform .3s ease,box-shadow .3s ease;}
+        .lp-gallery-item:hover{transform:translateY(-4px);box-shadow:0 14px 30px rgba(15,23,42,0.12);}
+        .lp-gallery-thumb{width:100%;height:100%;object-fit:cover;display:block;}
         .lp-video-wrapper{position:relative;padding-bottom:73.5%;height:0;overflow:hidden;}
         .lp-video-wrapper iframe{position:absolute;top:0;left:0;width:100%;height:100%;}
         #singlepostmap{width:100%;height:300px;border-radius:4px;}
@@ -271,11 +297,7 @@ if ( have_posts() ) {
         <header class="lp-onepage-header">
             <div class="container lp-onepage-header-inner">
             <div class="lp-onepage-brand">
-            <?php if ( ! empty( $business_logo_url ) ) : ?>
-                <div class="lp-onepage-logo"><img src="<?php echo esc_attr( $business_logo_url ); ?>" alt="<?php esc_attr_e( 'Listing Logo', 'listingpro' ); ?>"></div>
-            <?php else : ?>
-                <div class="lp-onepage-logo"><?php the_post_thumbnail( 'thumbnail' ); ?></div>
-            <?php endif; ?>
+                <div class="lp-onepage-logo"><?php echo $logo_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
             <span class="lp-onepage-name"><?php echo esc_html( $lp_title ); ?></span>
             </div>
             <nav class="lp-onepage-nav">
@@ -350,9 +372,9 @@ if ( have_posts() ) {
                         <section id="services" class="lp-section lp-section-services">
                             <div class="container">
                                 <h2 class="lp-section-title"><?php echo esc_html( $menu_items['services'] ); ?></h2>
-                                <ul>
-                                <?php foreach ( $services as $term ) : ?>
-                                    <li><?php echo esc_html( $term->name ); ?></li>
+                                <ul class="lp-services-list">
+                                <?php foreach ( $service_names as $service_name ) : ?>
+                                    <li><?php echo esc_html( $service_name ); ?></li>
                                 <?php endforeach; ?>
                                 </ul>
                             </div>
@@ -366,44 +388,21 @@ if ( have_posts() ) {
                         <section id="gallery" class="lp-section lp-section-gallery">
                             <div class="container">
                                 <h2 class="lp-section-title"><?php echo esc_html( $menu_items['gallery'] ); ?></h2>
-                                <?php
-                                $lp_detail_slider_styles = isset( $listingpro_options['lp_detail_slider_styles'] ) ? $listingpro_options['lp_detail_slider_styles'] : 'style1';
-                                $imgIDs                 = $gallery_ids;
-                                $numImages              = $num_gallery;
-                                if ( ! empty( $imgIDs ) && $numImages >= 1 ) :
-                                    if ( file_exists( THEME_PATH . '/include/aq_resizer.php' ) ) {
-                                        require_once THEME_PATH . '/include/aq_resizer.php';
-                                    }
-                                    ?>
-                                    <div class="pos-relative lp-onepage-gallery-slider">
-                                        <div class="spinner">
-                                            <div class="double-bounce1"></div>
-                                            <div class="double-bounce2"></div>
-                                        </div>
-                                        <div class="single-page-slider-container <?php echo esc_attr( $lp_detail_slider_styles ); ?>">
-                                            <div class="row">
-                                                <div class="col-md-12">
-                                                    <div class="<?php echo ( 'style2' === $lp_detail_slider_styles ) ? 'listing-slide' : 'listing-slide2'; ?> img_<?php echo esc_attr( $numImages ); ?>" data-images-num="<?php echo esc_attr( $numImages ); ?>">
-                                                        <?php
-                                                        foreach ( $imgIDs as $imgID ) {
-                                                            $img_url  = wp_get_attachment_image_src( $imgID, 'full' );
-                                                            $img_full = $img_url ? $img_url[0] : '';
-                                                            $img_src  = $img_full;
-                                                            if ( ! empty( $img_full ) && function_exists( 'aq_resize' ) ) {
-                                                                $resized = aq_resize( $img_full, 770, 566, true, true, true );
-                                                                if ( ! empty( $resized ) ) {
-                                                                    $img_src = $resized;
-                                                                }
-                                                            }
-                                                            if ( ! empty( $img_full ) ) {
-                                                                echo '<div class="slide"><a href="' . esc_url( $img_full ) . '" rel="prettyPhoto[gallery1]"><img src="' . esc_url( $img_src ) . '" alt="' . esc_attr( $lp_title ) . '" /></a></div>';
-                                                            }
-                                                        }
-                                                        ?>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        </div>
+                                <?php if ( ! empty( $gallery_ids ) ) : ?>
+                                    <div class="lp-gallery-grid">
+                                        <?php
+                                        foreach ( $gallery_ids as $img_id ) {
+                                            $full = wp_get_attachment_image_src( $img_id, 'full' );
+                                            if ( empty( $full[0] ) ) {
+                                                continue;
+                                            }
+                                            $thumb = wp_get_attachment_image( $img_id, 'large', false, array( 'class' => 'lp-gallery-thumb' ) );
+                                            if ( empty( $thumb ) ) {
+                                                $thumb = '<img class="lp-gallery-thumb" src="' . esc_url( $full[0] ) . '" alt="' . esc_attr( $lp_title ) . '" />';
+                                            }
+                                            echo '<a class="lp-gallery-item" href="' . esc_url( $full[0] ) . '" rel="prettyPhoto[gallery1]">' . $thumb . '</a>';
+                                        }
+                                        ?>
                                     </div>
                                 <?php endif; ?>
                             </div>
@@ -449,24 +448,6 @@ if ( have_posts() ) {
                         <?php
                     }
                     break;
-                case 'lp_offers_section':
-                    if ( isset( $menu_items['offers'] ) ) {
-                        ?>
-                        <section id="offers" class="lp-section lp-section-offers">
-                            <div class="container">
-                                <h2 class="lp-section-title"><?php echo esc_html( $menu_items['offers'] ); ?></h2>
-                                <?php
-                                $post_author_id = get_post_field( 'post_author', get_the_ID() );
-                                $discount_displayin = get_user_meta( $post_author_id, 'discount_display_area', true );
-                                if ( $discount_displayin == 'content' || empty( $discount_displayin ) ) {
-                                    get_template_part( 'templates/single-list/listing-details-style6/content/list-offer-deals-discount' );
-                                }
-                                ?>
-                            </div>
-                        </section>
-                        <?php
-                    }
-                    break;
                 case 'lp_menu_section':
                     if ( isset( $menu_items['menu'] ) ) {
                         ?>
@@ -503,18 +484,6 @@ if ( have_posts() ) {
                         <?php
                     }
                     break;
-                case 'lp_reviewform_section':
-                    if ( isset( $menu_items['reviewform'] ) ) {
-                        ?>
-                        <section id="reviewform" class="lp-section lp-section-reviewform">
-                            <div class="container">
-                                <h2 class="lp-section-title"><?php echo esc_html( $menu_items['reviewform'] ); ?></h2>
-                                <?php get_template_part( 'templates/single-list/listing-details-style6/content/reviewform' ); ?>
-                            </div>
-                        </section>
-                        <?php
-                    }
-                    break;
                 case 'lp_features_section':
                     if ( isset( $menu_items['features'] ) ) {
                         ?>
@@ -522,18 +491,6 @@ if ( have_posts() ) {
                             <div class="container">
                                 <h2 class="lp-section-title"><?php echo esc_html( $menu_items['features'] ); ?></h2>
                                 <?php get_template_part( 'templates/single-list/listing-details-style6/content/features' ); ?>
-                            </div>
-                        </section>
-                        <?php
-                    }
-                    break;
-                case 'lp_additional_section':
-                    if ( isset( $menu_items['additional'] ) ) {
-                        ?>
-                        <section id="additional" class="lp-section lp-section-additional">
-                            <div class="container">
-                                <h2 class="lp-section-title"><?php echo esc_html( $menu_items['additional'] ); ?></h2>
-                                <?php get_template_part( 'templates/single-list/listing-details-style6/content/additional' ); ?>
                             </div>
                         </section>
                         <?php

--- a/templates/listing-onepage.php
+++ b/templates/listing-onepage.php
@@ -239,11 +239,9 @@ if ( have_posts() ) {
             $price_html = listingpro_price_dynesty( get_the_ID() );
         }
 
-        $lp_title    = get_the_title();
-        $tagline_text = lp_onepage_meta( 'tagline_text' );
-        if ( empty( $tagline_text ) ) {
-            $tagline_text = '&nbsp;';
-        }
+        $lp_title      = get_the_title();
+        $tagline_text  = lp_onepage_meta( 'tagline_text' );
+        $tagline_plain = is_string( $tagline_text ) ? trim( wp_strip_all_tags( $tagline_text ) ) : '';
         $claimed_section = lp_onepage_meta( 'claimed_section' );
         $claimed_position = '';
         $title_len = strlen( $lp_title );
@@ -725,49 +723,116 @@ if ( have_posts() ) {
         }
         ?>
         <style>
-        .lp-onepage-header{position:sticky;top:0;background:#fff;z-index:999;border-bottom:1px solid #eee;}
-        .lp-onepage-header-inner{display:flex;align-items:center;justify-content:space-between;gap:30px;padding:15px 0;}
-        .lp-onepage-brand{display:flex;align-items:center;gap:15px;}
-        .lp-onepage-brand-link{display:flex;align-items:center;gap:15px;text-decoration:none;color:inherit;}
-        .lp-onepage-brand-link:hover{color:inherit;}
-        .lp-onepage-logo{width:60px;height:60px;border-radius:50%;overflow:hidden;display:flex;align-items:center;justify-content:center;background:#eef2f7;font-weight:700;font-size:22px;color:#1f2933;text-transform:uppercase;}
+        .lp-onepage-wrapper{position:relative;background:#f5f7fb;}
+        .lp-onepage-header{position:sticky;top:0;z-index:1000;background:rgba(255,255,255,0.96);backdrop-filter:blur(14px);border-bottom:1px solid rgba(148,163,184,0.2);}
+        .lp-onepage-header-inner{display:flex;align-items:center;justify-content:space-between;gap:24px;padding:14px 0;}
+        .lp-onepage-brand{display:flex;align-items:center;gap:14px;min-width:0;}
+        .lp-onepage-brand-link{display:flex;align-items:center;gap:14px;text-decoration:none;color:#0f172a;}
+        .lp-onepage-brand-link:hover{color:#2563eb;}
+        .lp-onepage-logo{width:64px;height:64px;border-radius:50%;overflow:hidden;display:flex;align-items:center;justify-content:center;background:linear-gradient(135deg,#e0f2fe 0%,#dbeafe 100%);font-weight:700;font-size:22px;color:#0f172a;text-transform:uppercase;box-shadow:0 8px 20px rgba(15,23,42,0.08);}
         .lp-onepage-logo img{width:100%;height:100%;object-fit:cover;}
-        .lp-logo-initial{display:block;width:100%;height:100%;line-height:60px;text-align:center;}
-        .lp-onepage-name{font-weight:700;font-size:20px;}
-        .lp-onepage-nav ul{list-style:none;margin:0;padding:0;display:flex;gap:30px;}
-        .lp-onepage-nav a{text-decoration:none;color:#333;font-weight:600;display:flex;align-items:center;gap:5px;}
-        .lp-onepage-nav a:hover{color:#0073aa;}
-        .lp-section{padding:60px 0;}
-        .lp-section .container{max-width:1170px;margin:0 auto;}
-        .lp-section-title{margin:0 0 30px;font-size:28px;font-weight:700;text-align:center;}
-        .lp-services-list{list-style:none;margin:0 auto;max-width:700px;padding:0;display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:12px;text-align:center;}
-        .lp-services-list li{background:#f7f9fc;border-radius:10px;padding:12px 16px;font-weight:600;color:#1f2933;box-shadow:0 8px 20px rgba(15,23,42,0.06);}
-        .lp-gallery-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:20px;}
-        .lp-gallery-item{display:block;overflow:hidden;border-radius:8px;box-shadow:0 10px 25px rgba(15,23,42,0.08);transition:transform .3s ease,box-shadow .3s ease;}
-        .lp-gallery-item:hover{transform:translateY(-4px);box-shadow:0 14px 30px rgba(15,23,42,0.12);}
+        .lp-logo-initial{display:flex;align-items:center;justify-content:center;width:100%;height:100%;}
+        .lp-onepage-name{font-weight:700;font-size:20px;line-height:1.2;color:#0f172a;}
+        .lp-menu-toggle{display:none;flex-direction:column;gap:5px;background:none;border:0;cursor:pointer;padding:4px;}
+        .lp-menu-toggle span{display:block;width:24px;height:2px;background:#0f172a;transition:all .3s ease;}
+        .lp-onepage-nav{margin-left:auto;}
+        .lp-onepage-nav ul{display:flex;gap:26px;align-items:center;list-style:none;margin:0;padding:0;}
+        .lp-onepage-nav li{position:relative;}
+        .lp-onepage-nav a{font-weight:600;color:#1f2937;text-decoration:none;display:flex;align-items:center;gap:6px;transition:color .2s ease;}
+        .lp-onepage-nav a:hover,.lp-onepage-nav a:focus{color:#2563eb;}
+        .lp-onepage-nav .lp-nav-phone a,.lp-onepage-nav .lp-nav-whatsapp a{padding:8px 14px;border-radius:999px;background:#f1f5f9;box-shadow:0 6px 16px rgba(15,23,42,0.08);}
+        .lp-onepage-nav .lp-nav-phone a:hover{background:#fee2e2;color:#b91c1c;}
+        .lp-onepage-nav .lp-nav-whatsapp a:hover{background:#dcfce7;color:#15803d;}
+        .lp-section{padding:72px 0;position:relative;}
+        .lp-section .container{max-width:1180px;margin:0 auto;padding:0 24px;}
+        .lp-section-title{margin:0 0 36px;font-size:32px;font-weight:700;text-align:center;color:#0f172a;}
+        .lp-services-list{list-style:none;margin:0 auto;max-width:780px;padding:0;display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:14px;text-align:center;}
+        .lp-services-list li{background:#fff;border-radius:14px;padding:16px 18px;font-weight:600;color:#1f2937;box-shadow:0 14px 30px rgba(15,23,42,0.08);}
+        .lp-gallery-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:22px;}
+        .lp-gallery-item{display:block;overflow:hidden;border-radius:16px;box-shadow:0 18px 36px rgba(15,23,42,0.12);transition:transform .3s ease,box-shadow .3s ease;}
+        .lp-gallery-item:hover{transform:translateY(-6px);box-shadow:0 24px 44px rgba(15,23,42,0.16);}
         .lp-gallery-thumb{width:100%;height:100%;object-fit:cover;display:block;}
-        .lp-video-wrapper{position:relative;padding-bottom:73.5%;height:0;overflow:hidden;}
-        .lp-video-wrapper iframe{position:absolute;top:0;left:0;width:100%;height:100%;}
-        #singlepostmap{width:100%;height:300px;border-radius:4px;}
-        .lp-contact-list{list-style:none;margin:0;padding:0;}
-        .lp-contact-list li{margin-bottom:8px;display:flex;align-items:center;gap:8px;}
-        .lp-contact-list i{width:16px;text-align:center;}
-        .lp-contact-list a{color:inherit;text-decoration:none;}
-        .lp-contact-list a:hover{text-decoration:underline;}
-        .lp-social-list{list-style:none;margin:20px 0 0;padding:0;display:flex;gap:10px;justify-content:center;}
-        .lp-social-list a{text-decoration:none;font-size:20px;}
-        .lp-listing-tagline{margin-top:10px;font-size:18px;color:#555;}
-        .lp-phone-float,.lp-whatsapp-float{position:fixed;right:20px;width:50px;height:50px;border-radius:50%;color:#fff;display:flex;align-items:center;justify-content:center;font-size:22px;z-index:1000;box-shadow:0 10px 24px rgba(15,23,42,0.2);}
-        .lp-phone-float{bottom:80px;background:#ef4444;}
-        .lp-phone-float:hover{background:#dc2626;color:#fff;}
-        .lp-whatsapp-float{bottom:20px;background:#25d366;}
-        .lp-whatsapp-float:hover{background:#1ebe5d;color:#fff;}
-        .lp-hero-banner{position:relative;min-height:360px;background-size:cover;background-position:center center;border-radius:12px;margin:20px auto;max-width:1170px;overflow:hidden;}
-        .lp-hero-banner .lp-header-overlay{position:absolute;top:0;left:0;width:100%;height:100%;background:rgba(15,23,42,0.25);}
-        .lp-quick-actions{max-width:1170px;margin:20px auto 0;display:flex;flex-wrap:wrap;gap:12px;justify-content:center;}
-        .lp-quick-actions a{display:flex;align-items:center;gap:8px;padding:10px 18px;border-radius:999px;background:#f1f5f9;color:#1f2933;font-weight:600;text-decoration:none;transition:all .2s ease;box-shadow:0 6px 18px rgba(15,23,42,0.08);}
-        .lp-quick-actions a:hover{background:#e2e8f0;color:#005f99;box-shadow:0 10px 24px rgba(15,23,42,0.12);}
-        .lp-quick-actions i{font-size:16px;}
+        .lp-video-wrapper{position:relative;padding-bottom:56.25%;height:0;overflow:hidden;border-radius:18px;box-shadow:0 16px 36px rgba(15,23,42,0.18);}
+        .lp-video-wrapper iframe{position:absolute;top:0;left:0;width:100%;height:100%;border:0;border-radius:18px;}
+        #singlepostmap{width:100%;height:360px;border-radius:16px;box-shadow:0 18px 40px rgba(15,23,42,0.1);}
+        .lp-contact-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:36px;align-items:flex-start;}
+        .lp-contact-card{background:#fff;border-radius:20px;padding:32px;box-shadow:0 22px 40px rgba(15,23,42,0.12);}
+        .lp-contact-list{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:14px;}
+        .lp-contact-list li{display:flex;align-items:center;gap:12px;font-size:15px;color:#1f2937;line-height:1.5;}
+        .lp-contact-list i{width:18px;text-align:center;font-size:16px;color:#2563eb;}
+        .lp-contact-list a{color:#0f172a;font-weight:600;text-decoration:none;}
+        .lp-contact-list a:hover{color:#2563eb;text-decoration:underline;}
+        .lp-social-list{list-style:none;margin:24px 0 0;padding:0;display:flex;gap:16px;justify-content:flex-start;}
+        .lp-social-list a{display:flex;align-items:center;justify-content:center;width:44px;height:44px;border-radius:12px;background:#eff6ff;color:#1d4ed8;font-size:20px;text-decoration:none;transition:all .2s ease;}
+        .lp-social-list a:hover{background:#2563eb;color:#fff;}
+        .lp-phone-float,.lp-whatsapp-float{position:fixed;right:24px;width:54px;height:54px;border-radius:50%;color:#fff;display:flex;align-items:center;justify-content:center;font-size:22px;z-index:999;box-shadow:0 14px 28px rgba(15,23,42,0.25);transition:transform .2s ease,box-shadow .2s ease;}
+        .lp-phone-float{bottom:96px;background:#ef4444;}
+        .lp-phone-float:hover{transform:translateY(-2px);box-shadow:0 20px 36px rgba(239,68,68,0.4);}
+        .lp-whatsapp-float{bottom:32px;background:#22c55e;}
+        .lp-whatsapp-float:hover{transform:translateY(-2px);box-shadow:0 20px 36px rgba(34,197,94,0.45);}
+        .lp-hero{position:relative;min-height:420px;border-radius:28px;overflow:hidden;display:flex;align-items:center;background-size:cover;background-position:center;box-shadow:0 28px 60px rgba(15,23,42,0.35);}
+        .lp-hero::after{content:"";position:absolute;inset:0;background:linear-gradient(120deg,rgba(15,23,42,0.75) 0%,rgba(30,64,175,0.55) 55%,rgba(59,130,246,0.45) 100%);}
+        .lp-hero-overlay{position:absolute;inset:0;}
+        .lp-hero-grid{position:relative;z-index:2;display:grid;grid-template-columns:minmax(0,3fr) minmax(0,2fr);gap:40px;width:100%;padding:48px 36px;}
+        .lp-hero-info{color:#fff;display:flex;flex-direction:column;gap:18px;}
+        .lp-hero-brand{display:flex;align-items:center;gap:20px;}
+        .lp-hero-logo{width:82px;height:82px;border-radius:50%;overflow:hidden;background:#fff;display:flex;align-items:center;justify-content:center;box-shadow:0 18px 36px rgba(15,23,42,0.35);}
+        .lp-hero-logo img{width:100%;height:100%;object-fit:cover;}
+        .lp-hero-text h1{margin:0;font-size:36px;font-weight:700;line-height:1.1;}
+        .lp-hero-claim{margin-top:10px;display:inline-flex;align-items:center;gap:10px;flex-wrap:wrap;}
+        .lp-hero-claim .claimed{display:inline-flex;align-items:center;gap:6px;border-radius:999px;padding:6px 12px;background:rgba(34,197,94,0.18);color:#ecfdf5;font-weight:600;font-size:13px;}
+        .lp-hero-claim .claimed i{color:#22c55e;}
+        .lp-hero-tagline{margin-top:6px;font-size:18px;color:rgba(241,245,249,0.88);font-weight:500;}
+        .lp-hero-rating{display:flex;align-items:center;gap:12px;margin-top:12px;flex-wrap:wrap;}
+        .lp-hero-rating-score{display:inline-flex;align-items:center;justify-content:center;width:48px;height:48px;border-radius:14px;background:#fcd34d;color:#78350f;font-weight:700;font-size:18px;}
+        .lp-hero-rating-count{font-size:15px;color:rgba(248,250,252,0.85);font-weight:600;}
+        .lp-hero-meta{list-style:none;margin:0;padding:0;display:flex;flex-wrap:wrap;gap:12px;}
+        .lp-hero-meta li{display:flex;align-items:center;gap:8px;padding:10px 14px;border-radius:999px;background:rgba(15,23,42,0.35);backdrop-filter:blur(6px);font-weight:600;font-size:14px;}
+        .lp-hero-meta i{font-size:15px;}
+        .lp-hero-card{background:#fff;border-radius:24px;padding:32px;box-shadow:0 28px 48px rgba(15,23,42,0.25);display:flex;flex-direction:column;gap:22px;}
+        .lp-hero-card h3{margin:0;font-size:20px;font-weight:700;color:#0f172a;}
+        .lp-hero-list{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:14px;}
+        .lp-hero-list li{display:flex;align-items:center;gap:10px;font-weight:600;color:#0f172a;}
+        .lp-hero-list i{width:18px;text-align:center;color:#2563eb;}
+        .lp-hero-buttons{display:flex;flex-wrap:wrap;gap:12px;}
+        .lp-hero-buttons a{flex:1 1 auto;min-width:140px;padding:12px 18px;border-radius:14px;text-decoration:none;font-weight:600;display:flex;align-items:center;justify-content:center;gap:8px;transition:transform .2s ease,box-shadow .2s ease;}
+        .lp-hero-buttons a:hover{transform:translateY(-2px);}
+        .lp-btn-phone{background:linear-gradient(135deg,#fee2e2,#fecaca);color:#b91c1c;box-shadow:0 16px 32px rgba(248,113,113,0.35);}
+        .lp-btn-whatsapp{background:linear-gradient(135deg,#dcfce7,#bbf7d0);color:#166534;box-shadow:0 16px 32px rgba(74,222,128,0.35);}
+        .lp-btn-website{background:linear-gradient(135deg,#e0f2fe,#bae6fd);color:#0c4a6e;box-shadow:0 16px 32px rgba(56,189,248,0.35);}
+        .lp-btn-hours{background:linear-gradient(135deg,#ede9fe,#ddd6fe);color:#5b21b6;box-shadow:0 16px 32px rgba(167,139,250,0.35);}
+        .lp-btn-map{background:linear-gradient(135deg,#fef9c3,#fde68a);color:#92400e;box-shadow:0 16px 32px rgba(250,204,21,0.35);}
+        .lp-onepage-wrapper .lp-section:nth-of-type(even){background:#fff;}
+        .lp-onepage-wrapper .lp-section:nth-of-type(odd){background:#f8fafc;}
+        .lp-section .container > p:last-child{margin-bottom:0;}
+        @media (max-width:1200px){
+            .lp-hero-grid{grid-template-columns:1fr;gap:28px;padding:42px 28px;}
+            .lp-hero-card{max-width:420px;margin:0 auto 12px;}
+        }
+        @media (max-width:992px){
+            .lp-onepage-header-inner{flex-wrap:wrap;}
+            .lp-menu-toggle{display:flex;}
+            .lp-onepage-nav{width:100%;order:3;}
+            .lp-onepage-nav ul{flex-direction:column;align-items:flex-start;gap:14px;padding:18px 0;display:none;}
+            .lp-onepage-nav.is-open ul{display:flex;}
+            .lp-onepage-nav li{width:100%;}
+            .lp-onepage-nav a{width:100%;justify-content:flex-start;}
+        }
+        @media (max-width:768px){
+            .lp-section{padding:56px 0;}
+            .lp-hero-text h1{font-size:30px;}
+            .lp-hero{min-height:380px;}
+            .lp-hero-meta{gap:10px;}
+            .lp-hero-meta li{font-size:13px;}
+        }
+        @media (max-width:576px){
+            .lp-onepage-logo{width:56px;height:56px;}
+            .lp-hero-logo{width:72px;height:72px;}
+            .lp-hero-buttons{flex-direction:column;}
+            .lp-hero-buttons a{width:100%;}
+            .lp-contact-card{padding:24px;}
+            .lp-onepage-nav .lp-nav-phone a,.lp-onepage-nav .lp-nav-whatsapp a{width:100%;justify-content:flex-start;}
+        }
         </style>
         <?php
         if ( $has_map && ! isset( $menu_items['map'] ) && in_array( 'lp_mapsocial_section', $layout_sections, true ) ) {
@@ -777,56 +842,117 @@ if ( have_posts() ) {
             $menu_items['hours'] = __( 'Çalışma Saatleri', 'listingpro' );
         }
         $menu_items['contact'] = __( 'İletişim', 'listingpro' );
+        $menu_items = array( 'home' => __( 'Anasayfa', 'listingpro' ) ) + $menu_items;
         ?>
         <div class="lp-onepage-wrapper">
         <header class="lp-onepage-header">
             <div class="container lp-onepage-header-inner">
-            <div class="lp-onepage-brand">
-                <a href="#home" class="lp-onepage-brand-link">
-                    <div class="lp-onepage-logo"><?php echo $logo_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
-                    <span class="lp-onepage-name"><?php echo esc_html( $lp_title ); ?></span>
-                </a>
-            </div>
-            <nav class="lp-onepage-nav">
-                <ul>
-                    <?php foreach ( $menu_items as $slug => $label ) : ?>
-                        <li><a href="#<?php echo esc_attr( $slug ); ?>"><?php echo esc_html( $label ); ?></a></li>
-                    <?php endforeach; ?>
-                    <?php if ( ! empty( $phone ) ) : ?>
-                        <li class="lp-nav-phone"><a href="tel:<?php echo esc_attr( $phone ); ?>"><i class="fa fa-phone"></i><?php echo esc_html( $phone ); ?></a></li>
-                    <?php endif; ?>
-                    <?php if ( ! empty( $whatsapp ) ) : ?>
-                        <li class="lp-nav-whatsapp"><a href="<?php echo esc_url( $wa_link ); ?>" target="_blank"><i class="fa fa-whatsapp"></i><?php echo esc_html( $whatsapp ); ?></a></li>
-                    <?php endif; ?>
-                </ul>
-            </nav>
+                <div class="lp-onepage-brand">
+                    <a href="#home" class="lp-onepage-brand-link">
+                        <div class="lp-onepage-logo"><?php echo $logo_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
+                        <span class="lp-onepage-name"><?php echo esc_html( $lp_title ); ?></span>
+                    </a>
+                </div>
+                <button class="lp-menu-toggle" type="button" aria-expanded="false" aria-controls="lp-onepage-nav">
+                    <span></span>
+                    <span></span>
+                    <span></span>
+                </button>
+                <nav class="lp-onepage-nav" id="lp-onepage-nav">
+                    <ul>
+                        <?php foreach ( $menu_items as $slug => $label ) : ?>
+                            <li><a href="#<?php echo esc_attr( $slug ); ?>"><?php echo esc_html( $label ); ?></a></li>
+                        <?php endforeach; ?>
+                        <?php if ( ! empty( $phone ) ) : ?>
+                            <li class="lp-nav-phone"><a href="tel:<?php echo esc_attr( $phone ); ?>"><i class="fa fa-phone"></i><?php echo esc_html( $phone ); ?></a></li>
+                        <?php endif; ?>
+                        <?php if ( ! empty( $whatsapp ) ) : ?>
+                            <li class="lp-nav-whatsapp"><a href="<?php echo esc_url( $wa_link ); ?>" target="_blank" rel="noopener"><i class="fa fa-whatsapp"></i><?php echo esc_html( $whatsapp ); ?></a></li>
+                        <?php endif; ?>
+                    </ul>
+                </nav>
             </div>
         </header>
 
         <section id="home" class="lp-section lp-section-home">
-            <div class="lp-hero-banner" <?php if ( ! empty( $hero_image_url ) ) : ?>style="background-image:url(<?php echo esc_url( $hero_image_url ); ?>)"<?php endif; ?>>
-                <div class="lp-header-overlay"></div>
+            <div class="lp-hero" <?php if ( ! empty( $hero_image_url ) ) : ?>style="background-image:url(<?php echo esc_url( $hero_image_url ); ?>)"<?php endif; ?>>
+                <span class="lp-hero-overlay" aria-hidden="true"></span>
+                <div class="container">
+                    <div class="lp-hero-grid">
+                        <div class="lp-hero-info">
+                            <div class="lp-hero-brand">
+                                <div class="lp-hero-logo"><?php echo $logo_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
+                                <div class="lp-hero-text">
+                                    <h1><?php echo esc_html( $lp_title ); ?></h1>
+                                    <?php if ( ! empty( $claim ) ) : ?>
+                                        <div class="lp-hero-claim"><?php echo $claim; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
+                                    <?php endif; ?>
+                                    <?php if ( ! empty( $tagline_plain ) ) : ?>
+                                        <div class="lp-hero-tagline"><?php echo esc_html( $tagline_plain ); ?></div>
+                                    <?php endif; ?>
+                                </div>
+                            </div>
+                            <?php if ( $NumberRating > 0 && floatval( $rating ) > 0 ) : ?>
+                                <div class="lp-hero-rating">
+                                    <span class="lp-hero-rating-score"><?php echo esc_html( number_format_i18n( floatval( $rating ), 1 ) ); ?></span>
+                                    <span class="lp-hero-rating-count"><?php printf( esc_html__( '%s değerlendirme', 'listingpro' ), esc_html( number_format_i18n( $NumberRating ) ) ); ?></span>
+                                </div>
+                            <?php endif; ?>
+                            <?php if ( ! empty( $locations ) || ! empty( $categories ) || ! empty( $price_html ) ) : ?>
+                                <ul class="lp-hero-meta">
+                                    <?php if ( ! empty( $locations ) ) : ?>
+                                        <li><i class="fa fa-map-marker"></i><?php echo esc_html( $locations[0]->name ); ?></li>
+                                    <?php endif; ?>
+                                    <?php if ( ! empty( $categories ) ) : ?>
+                                        <li><i class="fa fa-briefcase"></i><?php echo esc_html( $categories[0]->name ); ?></li>
+                                    <?php endif; ?>
+                                    <?php if ( ! empty( $price_html ) ) : ?>
+                                        <li><i class="fa fa-tag"></i><?php echo esc_html( wp_strip_all_tags( $price_html ) ); ?></li>
+                                    <?php endif; ?>
+                                </ul>
+                            <?php endif; ?>
+                        </div>
+                        <aside class="lp-hero-card">
+                            <h3><?php echo esc_html__( 'Hızlı Bilgiler', 'listingpro' ); ?></h3>
+                            <ul class="lp-hero-list">
+                                <?php if ( ! empty( $address ) ) : ?>
+                                    <li><i class="fa fa-location-arrow"></i><?php echo esc_html( $address ); ?></li>
+                                <?php endif; ?>
+                                <?php if ( 'yes' === $email_switcher && ! empty( $email ) ) : ?>
+                                    <li><i class="fa fa-envelope"></i><a href="mailto:<?php echo esc_attr( $email ); ?>"><?php echo esc_html( $email ); ?></a></li>
+                                <?php endif; ?>
+                                <?php if ( ! empty( $phone ) ) : ?>
+                                    <li><i class="fa fa-phone"></i><a href="tel:<?php echo esc_attr( $phone ); ?>"><?php echo esc_html( $phone ); ?></a></li>
+                                <?php endif; ?>
+                                <?php if ( ! empty( $whatsapp ) && ! empty( $wa_link ) ) : ?>
+                                    <li><i class="fa fa-whatsapp"></i><a href="<?php echo esc_url( $wa_link ); ?>" target="_blank" rel="noopener"><?php echo esc_html( $whatsapp ); ?></a></li>
+                                <?php endif; ?>
+                                <?php if ( ! empty( $website ) ) : ?>
+                                    <li><i class="fa fa-globe"></i><a href="<?php echo esc_url( $website ); ?>" target="_blank" rel="noopener"><?php echo esc_html( preg_replace( '#^https?://#i', '', $website ) ); ?></a></li>
+                                <?php endif; ?>
+                            </ul>
+                            <div class="lp-hero-buttons">
+                                <?php if ( ! empty( $phone ) ) : ?>
+                                    <a class="lp-btn-phone" href="tel:<?php echo esc_attr( $phone ); ?>"><i class="fa fa-phone"></i><?php echo esc_html__( 'Ara', 'listingpro' ); ?></a>
+                                <?php endif; ?>
+                                <?php if ( ! empty( $whatsapp ) && ! empty( $wa_link ) ) : ?>
+                                    <a class="lp-btn-whatsapp" href="<?php echo esc_url( $wa_link ); ?>" target="_blank" rel="noopener"><i class="fa fa-whatsapp"></i><?php echo esc_html__( 'WhatsApp', 'listingpro' ); ?></a>
+                                <?php endif; ?>
+                                <?php if ( ! empty( $website ) ) : ?>
+                                    <a class="lp-btn-website" href="<?php echo esc_url( $website ); ?>" target="_blank" rel="noopener"><i class="fa fa-globe"></i><?php echo esc_html__( 'Web Sitesi', 'listingpro' ); ?></a>
+                                <?php endif; ?>
+                                <?php if ( $has_hours ) : ?>
+                                    <a class="lp-btn-hours" href="#hours"><i class="fa fa-clock-o"></i><?php echo esc_html__( 'Çalışma Saatleri', 'listingpro' ); ?></a>
+                                <?php endif; ?>
+                                <?php if ( $has_map && ! empty( $latitude ) && ! empty( $longitude ) ) : ?>
+                                    <a class="lp-btn-map" href="https://www.google.com/maps/search/?api=1&amp;query=<?php echo esc_attr( $latitude ); ?>,<?php echo esc_attr( $longitude ); ?>" target="_blank" rel="noopener"><i class="fa fa-map-marker"></i><?php echo esc_html__( 'Yol Tarifi', 'listingpro' ); ?></a>
+                                <?php endif; ?>
+                            </div>
+                        </aside>
+                    </div>
+                </div>
             </div>
         </section>
-        <?php if ( ! empty( $phone ) || ! empty( $website ) || ! empty( $whatsapp ) || $has_hours || ( $has_map && ! empty( $latitude ) && ! empty( $longitude ) ) ) : ?>
-            <div class="lp-quick-actions">
-                <?php if ( ! empty( $phone ) ) : ?>
-                    <a href="tel:<?php echo esc_attr( $phone ); ?>"><i class="fa fa-phone"></i><?php echo esc_html( $phone ); ?></a>
-                <?php endif; ?>
-                <?php if ( ! empty( $whatsapp ) ) : ?>
-                    <a href="<?php echo esc_url( $wa_link ); ?>" target="_blank" rel="noopener"><i class="fa fa-whatsapp"></i><?php echo esc_html__( 'WhatsApp', 'listingpro' ); ?></a>
-                <?php endif; ?>
-                <?php if ( ! empty( $website ) ) : ?>
-                    <a href="<?php echo esc_url( $website ); ?>" target="_blank" rel="noopener"><i class="fa fa-globe"></i><?php echo esc_html__( 'Web Sitesi', 'listingpro' ); ?></a>
-                <?php endif; ?>
-                <?php if ( $has_hours ) : ?>
-                    <a href="#hours"><i class="fa fa-clock-o"></i><?php echo esc_html__( 'Çalışma Saatleri', 'listingpro' ); ?></a>
-                <?php endif; ?>
-                <?php if ( $has_map && ! empty( $latitude ) && ! empty( $longitude ) ) : ?>
-                    <a href="https://www.google.com/maps/search/?api=1&amp;query=<?php echo esc_attr( $latitude ); ?>,<?php echo esc_attr( $longitude ); ?>" target="_blank" rel="noopener"><i class="fa fa-map-marker"></i><?php echo esc_html__( 'Harita', 'listingpro' ); ?></a>
-                <?php endif; ?>
-            </div>
-        <?php endif; ?>
         <?php foreach ( $sections_markup as $section_html ) : ?>
             <?php echo $section_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
         <?php endforeach; ?>
@@ -850,61 +976,75 @@ if ( have_posts() ) {
             </section>
         <?php endif; ?>
 
+        <?php
+        $additional_pos    = isset( $listingpro_options['lp_detail_page_additional_styles'] ) ? $listingpro_options['lp_detail_page_additional_styles'] : '';
+        $extra_right_html  = '';
+        if ( function_exists( 'listing_all_extra_fields_v2_right' ) && 'right' === $additional_pos ) {
+            $extra_right_html = listing_all_extra_fields_v2_right( get_the_ID() );
+        }
+        ob_start();
+        get_template_part( 'templates/single-list/listing-details-style3/sidebar/lead-form' );
+        $lead_form_html = trim( ob_get_clean() );
+        ?>
+
         <section id="contact" class="lp-section lp-section-contact">
             <div class="container">
                 <h2 class="lp-section-title"><?php echo esc_html( $menu_items['contact'] ); ?></h2>
-                <ul class="lp-contact-list">
-                    <?php if ( ! empty( $locations ) ) : ?>
-                        <li class="lp-contact-location"><i class="fa fa-map-marker"></i><?php echo esc_html( $locations[0]->name ); ?></li>
-                    <?php endif; ?>
-                    <?php if ( ! empty( $categories ) ) : ?>
-                        <li class="lp-contact-category"><i class="fa fa-folder-open"></i><?php echo esc_html( $categories[0]->name ); ?></li>
-                    <?php endif; ?>
-                    <?php if ( ! empty( $address ) ) : ?>
-                        <li class="lp-contact-address"><i class="fa fa-location-arrow"></i><?php echo esc_html( $address ); ?><?php if ( ! empty( $latitude ) && ! empty( $longitude ) ) : ?> <a href="https://www.google.com/maps/search/?api=1&amp;query=<?php echo esc_attr( $latitude ); ?>,<?php echo esc_attr( $longitude ); ?>" target="_blank"><?php echo esc_html__( 'Yol Tarifi Al', 'listingpro' ); ?></a><?php endif; ?></li>
-                    <?php endif; ?>
-                    <?php if ( 'yes' === $email_switcher && ! empty( $email ) ) : ?>
-                        <li class="lp-contact-email"><i class="fa fa-envelope"></i><a href="mailto:<?php echo esc_attr( $email ); ?>"><?php echo esc_html( $email ); ?></a></li>
-                    <?php endif; ?>
-                    <?php if ( ! empty( $phone ) ) : ?>
-                        <li class="lp-contact-phone"><i class="fa fa-phone"></i><a href="tel:<?php echo esc_attr( $phone ); ?>"><?php echo esc_html( $phone ); ?></a></li>
-                    <?php endif; ?>
-                    <?php if ( ! empty( $whatsapp ) && ! empty( $wa_link ) ) : ?>
-                        <li class="lp-contact-whatsapp"><i class="fa fa-whatsapp"></i><a href="<?php echo esc_url( $wa_link ); ?>" target="_blank"><?php echo esc_html( $whatsapp ); ?></a></li>
-                    <?php endif; ?>
-                    <?php if ( ! empty( $website ) ) : ?>
-                        <li class="lp-contact-website"><i class="fa fa-globe"></i><a href="<?php echo esc_url( $website ); ?>" target="_blank"><?php echo esc_html( $website ); ?></a></li>
-                    <?php endif; ?>
-                    <?php if ( ! empty( $price_html ) ) : ?>
-                        <li class="lp-contact-price"><?php echo wp_kses_post( $price_html ); ?></li>
-                    <?php endif; ?>
-                    <?php if ( ! empty( $tags_terms ) ) :
-                        $tag_names = array();
-                        foreach ( $tags_terms as $tag_term ) {
-                            $tag_names[] = $tag_term->name;
-                        }
-                        $tag_names = array_filter( $tag_names );
-                        if ( ! empty( $tag_names ) ) : ?>
-                        <li class="lp-contact-tags"><i class="fa fa-tags"></i><?php echo esc_html( implode( ', ', $tag_names ) ); ?></li>
+                <div class="lp-contact-grid">
+                    <div class="lp-contact-card">
+                        <ul class="lp-contact-list">
+                            <?php if ( ! empty( $locations ) ) : ?>
+                                <li class="lp-contact-location"><i class="fa fa-map-marker"></i><?php echo esc_html( $locations[0]->name ); ?></li>
+                            <?php endif; ?>
+                            <?php if ( ! empty( $categories ) ) : ?>
+                                <li class="lp-contact-category"><i class="fa fa-folder-open"></i><?php echo esc_html( $categories[0]->name ); ?></li>
+                            <?php endif; ?>
+                            <?php if ( ! empty( $address ) ) : ?>
+                                <li class="lp-contact-address"><i class="fa fa-location-arrow"></i><?php echo esc_html( $address ); ?><?php if ( ! empty( $latitude ) && ! empty( $longitude ) ) : ?> <a href="https://www.google.com/maps/search/?api=1&amp;query=<?php echo esc_attr( $latitude ); ?>,<?php echo esc_attr( $longitude ); ?>" target="_blank" rel="noopener"><?php echo esc_html__( 'Yol Tarifi Al', 'listingpro' ); ?></a><?php endif; ?></li>
+                            <?php endif; ?>
+                            <?php if ( 'yes' === $email_switcher && ! empty( $email ) ) : ?>
+                                <li class="lp-contact-email"><i class="fa fa-envelope"></i><a href="mailto:<?php echo esc_attr( $email ); ?>"><?php echo esc_html( $email ); ?></a></li>
+                            <?php endif; ?>
+                            <?php if ( ! empty( $phone ) ) : ?>
+                                <li class="lp-contact-phone"><i class="fa fa-phone"></i><a href="tel:<?php echo esc_attr( $phone ); ?>"><?php echo esc_html( $phone ); ?></a></li>
+                            <?php endif; ?>
+                            <?php if ( ! empty( $whatsapp ) && ! empty( $wa_link ) ) : ?>
+                                <li class="lp-contact-whatsapp"><i class="fa fa-whatsapp"></i><a href="<?php echo esc_url( $wa_link ); ?>" target="_blank" rel="noopener"><?php echo esc_html( $whatsapp ); ?></a></li>
+                            <?php endif; ?>
+                            <?php if ( ! empty( $website ) ) : ?>
+                                <li class="lp-contact-website"><i class="fa fa-globe"></i><a href="<?php echo esc_url( $website ); ?>" target="_blank" rel="noopener"><?php echo esc_html( $website ); ?></a></li>
+                            <?php endif; ?>
+                            <?php if ( ! empty( $price_html ) ) : ?>
+                                <li class="lp-contact-price"><?php echo wp_kses_post( $price_html ); ?></li>
+                            <?php endif; ?>
+                            <?php if ( ! empty( $tags_terms ) ) :
+                                $tag_names = array();
+                                foreach ( $tags_terms as $tag_term ) {
+                                    $tag_names[] = $tag_term->name;
+                                }
+                                $tag_names = array_filter( $tag_names );
+                                if ( ! empty( $tag_names ) ) : ?>
+                                <li class="lp-contact-tags"><i class="fa fa-tags"></i><?php echo esc_html( implode( ', ', $tag_names ) ); ?></li>
+                                <?php endif; ?>
+                            <?php endif; ?>
+                        </ul>
+                        <?php if ( lp_onepage_on( $social_show ) && ( $facebook || $twitter || $linkedin || $youtube || $instagram ) ) : ?>
+                            <ul class="lp-social-list">
+                                <?php if ( ! empty( $facebook ) ) : ?><li><a href="<?php echo esc_url( $facebook ); ?>" target="_blank" rel="noopener"><i class="fa fa-facebook-square"></i></a></li><?php endif; ?>
+                                <?php if ( ! empty( $twitter ) ) : ?><li><a href="<?php echo esc_url( $twitter ); ?>" target="_blank" rel="noopener"><i class="fa fa-twitter"></i></a></li><?php endif; ?>
+                                <?php if ( ! empty( $linkedin ) ) : ?><li><a href="<?php echo esc_url( $linkedin ); ?>" target="_blank" rel="noopener"><i class="fa fa-linkedin"></i></a></li><?php endif; ?>
+                                <?php if ( ! empty( $youtube ) ) : ?><li><a href="<?php echo esc_url( $youtube ); ?>" target="_blank" rel="noopener"><i class="fa fa-youtube"></i></a></li><?php endif; ?>
+                                <?php if ( ! empty( $instagram ) ) : ?><li><a href="<?php echo esc_url( $instagram ); ?>" target="_blank" rel="noopener"><i class="fa fa-instagram"></i></a></li><?php endif; ?>
+                            </ul>
                         <?php endif; ?>
+                    </div>
+                    <?php if ( ! empty( $extra_right_html ) || ! empty( $lead_form_html ) ) : ?>
+                        <div class="lp-contact-card">
+                            <?php echo $extra_right_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                            <?php echo $lead_form_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                        </div>
                     <?php endif; ?>
-                </ul>
-                <?php if ( lp_onepage_on( $social_show ) && ( $facebook || $twitter || $linkedin || $youtube || $instagram ) ) : ?>
-                    <ul class="lp-social-list">
-                        <?php if ( ! empty( $facebook ) ) : ?><li><a href="<?php echo esc_url( $facebook ); ?>" target="_blank"><i class="fa fa-facebook-square"></i></a></li><?php endif; ?>
-                        <?php if ( ! empty( $twitter ) ) : ?><li><a href="<?php echo esc_url( $twitter ); ?>" target="_blank"><i class="fa fa-twitter"></i></a></li><?php endif; ?>
-                        <?php if ( ! empty( $linkedin ) ) : ?><li><a href="<?php echo esc_url( $linkedin ); ?>" target="_blank"><i class="fa fa-linkedin"></i></a></li><?php endif; ?>
-                        <?php if ( ! empty( $youtube ) ) : ?><li><a href="<?php echo esc_url( $youtube ); ?>" target="_blank"><i class="fa fa-youtube"></i></a></li><?php endif; ?>
-                        <?php if ( ! empty( $instagram ) ) : ?><li><a href="<?php echo esc_url( $instagram ); ?>" target="_blank"><i class="fa fa-instagram"></i></a></li><?php endif; ?>
-                    </ul>
-                <?php endif; ?>
-                <?php
-                $additional_pos = isset( $listingpro_options['lp_detail_page_additional_styles'] ) ? $listingpro_options['lp_detail_page_additional_styles'] : '';
-                if ( function_exists( 'listing_all_extra_fields_v2_right' ) && 'right' === $additional_pos ) {
-                    echo listing_all_extra_fields_v2_right( get_the_ID() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-                }
-                ?>
-                <?php get_template_part( 'templates/single-list/listing-details-style3/sidebar/lead-form' ); ?>
+                </div>
             </div>
         </section>
         <?php if ( ! empty( $phone ) ) : ?>
@@ -916,12 +1056,52 @@ if ( have_posts() ) {
 
         <script>
         jQuery(function($){
-            $('.lp-onepage-nav a').on('click', function(e){
-                e.preventDefault();
-                var target = this.hash;
-                $('html, body').animate({
-                    scrollTop: $(target).offset().top
-                }, 500);
+            var $window  = $(window);
+            var $header  = $('.lp-onepage-header');
+            var $toggle  = $('.lp-menu-toggle');
+            var $nav     = $('.lp-onepage-nav');
+            var headerGap = 14;
+
+            function getHeaderOffset() {
+                return $header.length ? $header.outerHeight() + headerGap : headerGap;
+            }
+
+            function closeMenu() {
+                $nav.removeClass('is-open');
+                $toggle.attr('aria-expanded', 'false');
+            }
+
+            $toggle.on('click', function(){
+                var expanded = $(this).attr('aria-expanded') === 'true';
+                $(this).attr('aria-expanded', expanded ? 'false' : 'true');
+                $nav.toggleClass('is-open', !expanded);
+            });
+
+            $('.lp-onepage-wrapper').on('click', 'a[href^="#"]', function(e){
+                var targetSelector = this.getAttribute('href');
+                if (!targetSelector) {
+                    return;
+                }
+
+                var $target = $(targetSelector);
+                if ( $target.length ) {
+                    e.preventDefault();
+                    var offset = $target.offset().top - getHeaderOffset();
+                    if ( offset < 0 ) {
+                        offset = 0;
+                    }
+                    $('html, body').animate({ scrollTop: offset }, 500);
+                }
+
+                if ( $nav.hasClass('is-open') ) {
+                    closeMenu();
+                }
+            });
+
+            $window.on('resize', function(){
+                if ( window.innerWidth >= 992 ) {
+                    closeMenu();
+                }
             });
         });
         </script>

--- a/templates/listing-onepage.php
+++ b/templates/listing-onepage.php
@@ -766,7 +766,7 @@ if ( have_posts() ) {
         .lp-hero{position:relative;min-height:420px;border-radius:28px;overflow:hidden;display:flex;align-items:center;background-size:cover;background-position:center;box-shadow:0 28px 60px rgba(15,23,42,0.35);}
         .lp-hero::after{content:"";position:absolute;inset:0;background:linear-gradient(120deg,rgba(15,23,42,0.75) 0%,rgba(30,64,175,0.55) 55%,rgba(59,130,246,0.45) 100%);}
         .lp-hero-overlay{position:absolute;inset:0;}
-        .lp-hero-grid{position:relative;z-index:2;display:grid;grid-template-columns:minmax(0,3fr) minmax(0,2fr);gap:40px;width:100%;padding:48px 36px;}
+        .lp-hero-grid{position:relative;z-index:2;display:flex;flex-direction:column;gap:32px;width:100%;padding:48px 36px;}
         .lp-hero-info{color:#fff;display:flex;flex-direction:column;gap:18px;}
         .lp-hero-brand{display:flex;align-items:center;gap:20px;}
         .lp-hero-logo{width:82px;height:82px;border-radius:50%;overflow:hidden;background:#fff;display:flex;align-items:center;justify-content:center;box-shadow:0 18px 36px rgba(15,23,42,0.35);}
@@ -782,25 +782,11 @@ if ( have_posts() ) {
         .lp-hero-meta{list-style:none;margin:0;padding:0;display:flex;flex-wrap:wrap;gap:12px;}
         .lp-hero-meta li{display:flex;align-items:center;gap:8px;padding:10px 14px;border-radius:999px;background:rgba(15,23,42,0.35);backdrop-filter:blur(6px);font-weight:600;font-size:14px;}
         .lp-hero-meta i{font-size:15px;}
-        .lp-hero-card{background:#fff;border-radius:24px;padding:32px;box-shadow:0 28px 48px rgba(15,23,42,0.25);display:flex;flex-direction:column;gap:22px;}
-        .lp-hero-card h3{margin:0;font-size:20px;font-weight:700;color:#0f172a;}
-        .lp-hero-list{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:14px;}
-        .lp-hero-list li{display:flex;align-items:center;gap:10px;font-weight:600;color:#0f172a;}
-        .lp-hero-list i{width:18px;text-align:center;color:#2563eb;}
-        .lp-hero-buttons{display:flex;flex-wrap:wrap;gap:12px;}
-        .lp-hero-buttons a{flex:1 1 auto;min-width:140px;padding:12px 18px;border-radius:14px;text-decoration:none;font-weight:600;display:flex;align-items:center;justify-content:center;gap:8px;transition:transform .2s ease,box-shadow .2s ease;}
-        .lp-hero-buttons a:hover{transform:translateY(-2px);}
-        .lp-btn-phone{background:linear-gradient(135deg,#fee2e2,#fecaca);color:#b91c1c;box-shadow:0 16px 32px rgba(248,113,113,0.35);}
-        .lp-btn-whatsapp{background:linear-gradient(135deg,#dcfce7,#bbf7d0);color:#166534;box-shadow:0 16px 32px rgba(74,222,128,0.35);}
-        .lp-btn-website{background:linear-gradient(135deg,#e0f2fe,#bae6fd);color:#0c4a6e;box-shadow:0 16px 32px rgba(56,189,248,0.35);}
-        .lp-btn-hours{background:linear-gradient(135deg,#ede9fe,#ddd6fe);color:#5b21b6;box-shadow:0 16px 32px rgba(167,139,250,0.35);}
-        .lp-btn-map{background:linear-gradient(135deg,#fef9c3,#fde68a);color:#92400e;box-shadow:0 16px 32px rgba(250,204,21,0.35);}
         .lp-onepage-wrapper .lp-section:nth-of-type(even){background:#fff;}
         .lp-onepage-wrapper .lp-section:nth-of-type(odd){background:#f8fafc;}
         .lp-section .container > p:last-child{margin-bottom:0;}
         @media (max-width:1200px){
-            .lp-hero-grid{grid-template-columns:1fr;gap:28px;padding:42px 28px;}
-            .lp-hero-card{max-width:420px;margin:0 auto 12px;}
+            .lp-hero-grid{padding:42px 28px;}
         }
         @media (max-width:992px){
             .lp-onepage-header-inner{flex-wrap:wrap;}
@@ -821,8 +807,6 @@ if ( have_posts() ) {
         @media (max-width:576px){
             .lp-onepage-logo{width:56px;height:56px;}
             .lp-hero-logo{width:72px;height:72px;}
-            .lp-hero-buttons{flex-direction:column;}
-            .lp-hero-buttons a{width:100%;}
             .lp-contact-card{padding:24px;}
             .lp-onepage-nav .lp-nav-phone a,.lp-onepage-nav .lp-nav-whatsapp a{width:100%;justify-content:flex-start;}
         }
@@ -905,43 +889,6 @@ if ( have_posts() ) {
                                 </ul>
                             <?php endif; ?>
                         </div>
-                        <aside class="lp-hero-card">
-                            <h3><?php echo esc_html__( 'Hızlı Bilgiler', 'listingpro' ); ?></h3>
-                            <ul class="lp-hero-list">
-                                <?php if ( ! empty( $address ) ) : ?>
-                                    <li><i class="fa fa-location-arrow"></i><?php echo esc_html( $address ); ?></li>
-                                <?php endif; ?>
-                                <?php if ( 'yes' === $email_switcher && ! empty( $email ) ) : ?>
-                                    <li><i class="fa fa-envelope"></i><a href="mailto:<?php echo esc_attr( $email ); ?>"><?php echo esc_html( $email ); ?></a></li>
-                                <?php endif; ?>
-                                <?php if ( ! empty( $phone ) ) : ?>
-                                    <li><i class="fa fa-phone"></i><a href="tel:<?php echo esc_attr( $phone ); ?>"><?php echo esc_html( $phone ); ?></a></li>
-                                <?php endif; ?>
-                                <?php if ( ! empty( $whatsapp ) && ! empty( $wa_link ) ) : ?>
-                                    <li><i class="fa fa-whatsapp"></i><a href="<?php echo esc_url( $wa_link ); ?>" target="_blank" rel="noopener"><?php echo esc_html( $whatsapp ); ?></a></li>
-                                <?php endif; ?>
-                                <?php if ( ! empty( $website ) ) : ?>
-                                    <li><i class="fa fa-globe"></i><a href="<?php echo esc_url( $website ); ?>" target="_blank" rel="noopener"><?php echo esc_html( preg_replace( '#^https?://#i', '', $website ) ); ?></a></li>
-                                <?php endif; ?>
-                            </ul>
-                            <div class="lp-hero-buttons">
-                                <?php if ( ! empty( $phone ) ) : ?>
-                                    <a class="lp-btn-phone" href="tel:<?php echo esc_attr( $phone ); ?>"><i class="fa fa-phone"></i><?php echo esc_html__( 'Ara', 'listingpro' ); ?></a>
-                                <?php endif; ?>
-                                <?php if ( ! empty( $whatsapp ) && ! empty( $wa_link ) ) : ?>
-                                    <a class="lp-btn-whatsapp" href="<?php echo esc_url( $wa_link ); ?>" target="_blank" rel="noopener"><i class="fa fa-whatsapp"></i><?php echo esc_html__( 'WhatsApp', 'listingpro' ); ?></a>
-                                <?php endif; ?>
-                                <?php if ( ! empty( $website ) ) : ?>
-                                    <a class="lp-btn-website" href="<?php echo esc_url( $website ); ?>" target="_blank" rel="noopener"><i class="fa fa-globe"></i><?php echo esc_html__( 'Web Sitesi', 'listingpro' ); ?></a>
-                                <?php endif; ?>
-                                <?php if ( $has_hours ) : ?>
-                                    <a class="lp-btn-hours" href="#hours"><i class="fa fa-clock-o"></i><?php echo esc_html__( 'Çalışma Saatleri', 'listingpro' ); ?></a>
-                                <?php endif; ?>
-                                <?php if ( $has_map && ! empty( $latitude ) && ! empty( $longitude ) ) : ?>
-                                    <a class="lp-btn-map" href="https://www.google.com/maps/search/?api=1&amp;query=<?php echo esc_attr( $latitude ); ?>,<?php echo esc_attr( $longitude ); ?>" target="_blank" rel="noopener"><i class="fa fa-map-marker"></i><?php echo esc_html__( 'Yol Tarifi', 'listingpro' ); ?></a>
-                                <?php endif; ?>
-                            </div>
-                        </aside>
                     </div>
                 </div>
             </div>

--- a/templates/listing-onepage.php
+++ b/templates/listing-onepage.php
@@ -292,7 +292,7 @@ if ( have_posts() ) {
         $has_hours = is_array( $hours ) ? ! empty( array_filter( $hours ) ) : ! empty( $hours );
 
         $sections_markup = array();
-        $menu_items      = array( 'home' => __( 'Anasayfa', 'listingpro' ) );
+        $menu_items      = array();
         
         foreach ( $layout_sections as $section_key ) {
             switch ( $section_key ) {
@@ -631,7 +631,6 @@ if ( have_posts() ) {
                     </section>
                     <?php
                     $sections_markup['reviews'] = ob_get_clean();
-                    $menu_items['reviews']      = __( 'Yorumlar', 'listingpro' );
                     break;
 
                 case 'lp_reviewform_section':
@@ -658,23 +657,16 @@ if ( have_posts() ) {
         }
 
         $preferred_menu_order = array(
-            'home'    => __( 'Anasayfa', 'listingpro' ),
             'about'   => __( 'Hakkımızda', 'listingpro' ),
             'services'=> __( 'Hizmetler', 'listingpro' ),
             'video'   => __( 'Video', 'listingpro' ),
             'gallery' => __( 'Resim', 'listingpro' ),
-            'reviews' => __( 'Yorumlar', 'listingpro' ),
             'hours'   => __( 'Çalışma Saatleri', 'listingpro' ),
             'contact' => __( 'İletişim', 'listingpro' ),
         );
 
         $filtered_menu = array();
         foreach ( $preferred_menu_order as $slug => $label ) {
-            if ( 'home' === $slug ) {
-                $filtered_menu[ $slug ] = $label;
-                continue;
-            }
-
             if ( 'hours' === $slug ) {
                 if ( $has_hours ) {
                     $filtered_menu[ $slug ] = $label;
@@ -736,6 +728,8 @@ if ( have_posts() ) {
         .lp-onepage-header{position:sticky;top:0;background:#fff;z-index:999;border-bottom:1px solid #eee;}
         .lp-onepage-header-inner{display:flex;align-items:center;justify-content:space-between;gap:30px;padding:15px 0;}
         .lp-onepage-brand{display:flex;align-items:center;gap:15px;}
+        .lp-onepage-brand-link{display:flex;align-items:center;gap:15px;text-decoration:none;color:inherit;}
+        .lp-onepage-brand-link:hover{color:inherit;}
         .lp-onepage-logo{width:60px;height:60px;border-radius:50%;overflow:hidden;display:flex;align-items:center;justify-content:center;background:#eef2f7;font-weight:700;font-size:22px;color:#1f2933;text-transform:uppercase;}
         .lp-onepage-logo img{width:100%;height:100%;object-fit:cover;}
         .lp-logo-initial{display:block;width:100%;height:100%;line-height:60px;text-align:center;}
@@ -784,8 +778,10 @@ if ( have_posts() ) {
         <header class="lp-onepage-header">
             <div class="container lp-onepage-header-inner">
             <div class="lp-onepage-brand">
-                <div class="lp-onepage-logo"><?php echo $logo_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
-            <span class="lp-onepage-name"><?php echo esc_html( $lp_title ); ?></span>
+                <a href="#home" class="lp-onepage-brand-link">
+                    <div class="lp-onepage-logo"><?php echo $logo_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
+                    <span class="lp-onepage-name"><?php echo esc_html( $lp_title ); ?></span>
+                </a>
             </div>
             <nav class="lp-onepage-nav">
                 <ul>

--- a/templates/listing-onepage.php
+++ b/templates/listing-onepage.php
@@ -53,23 +53,61 @@ if ( have_posts() ) {
             }
         }
 
-        $layout_general = array(
-            'lp_content_section',
-            'lp_services_section',
-            'lp_features_section',
-            'lp_gallery_section',
-            'lp_video_section',
-            'lp_announcements_section',
-            'lp_offers_section',
-            'lp_menu_section',
-            'lp_event_section',
-            'lp_booking_section',
-            'lp_quicks_section',
-            'lp_faqs_section',
-            'lp_additional_section',
-            'lp_reviews_section',
-            'lp_reviewform_section',
-        );
+        if ( ! function_exists( 'lp_onepage_collect_keys' ) ) {
+            function lp_onepage_collect_keys( $option_array ) {
+                $keys = array();
+                if ( is_array( $option_array ) ) {
+                    foreach ( $option_array as $key => $value ) {
+                        if ( is_string( $key ) && '' !== $key && ! is_numeric( $key ) ) {
+                            $keys[] = $key;
+                        } elseif ( is_string( $value ) && '' !== $value ) {
+                            $keys[] = $value;
+                        }
+                    }
+                }
+                return $keys;
+            }
+        }
+
+        $layout_general = array();
+        if ( isset( $listingpro_options['lp-detail-page-layout4-content']['general'] ) ) {
+            $layout_general = lp_onepage_collect_keys( $listingpro_options['lp-detail-page-layout4-content']['general'] );
+        }
+
+        $layout_sidebar = array();
+        if ( isset( $listingpro_options['lp-detail-page-layout4-rsidebar']['sidebar'] ) ) {
+            $layout_sidebar = lp_onepage_collect_keys( $listingpro_options['lp-detail-page-layout4-rsidebar']['sidebar'] );
+        }
+
+        $layout_sections = $layout_general;
+        foreach ( $layout_sidebar as $sidebar_key ) {
+            if ( ! in_array( $sidebar_key, $layout_sections, true ) ) {
+                $layout_sections[] = $sidebar_key;
+            }
+        }
+
+        if ( empty( $layout_sections ) ) {
+            $layout_sections = array(
+                'lp_content_section',
+                'lp_services_section',
+                'lp_features_section',
+                'lp_gallery_section',
+                'lp_video_section',
+                'lp_announcements_section',
+                'lp_offers_section',
+                'lp_menu_section',
+                'lp_event_section',
+                'lp_booking_section',
+                'lp_quicks_section',
+                'lp_faqs_section',
+                'lp_additional_section',
+                'lp_reviews_section',
+                'lp_reviewform_section',
+                'lp_sidebar_video',
+                'lp_mapsocial_section',
+                'lp_timing_section',
+            );
+        }
 
         $description = lp_onepage_meta( 'lp_listing_description' );
         if ( empty( $description ) ) {
@@ -223,7 +261,7 @@ if ( have_posts() ) {
         $sections_markup = array();
         $menu_items      = array( 'home' => __( 'Anasayfa', 'listingpro' ) );
         
-        foreach ( $layout_general as $section_key ) {
+        foreach ( $layout_sections as $section_key ) {
             switch ( $section_key ) {
                 case 'lp_content_section':
                     if ( empty( $description ) || isset( $sections_markup['about'] ) ) {
@@ -316,6 +354,7 @@ if ( have_posts() ) {
                     $menu_items['gallery']      = __( 'Resim', 'listingpro' );
                     break;
 
+                case 'lp_sidebar_video':
                 case 'lp_video_section':
                     if ( empty( $video_html ) || isset( $sections_markup['video'] ) ) {
                         break;
@@ -579,14 +618,6 @@ if ( have_posts() ) {
             }
         }
 
-        if ( $has_map ) {
-            $menu_items['map'] = __( 'Harita', 'listingpro' );
-        }
-        if ( $has_hours ) {
-            $menu_items['hours'] = __( 'Çalışma Saatleri', 'listingpro' );
-        }
-        $menu_items['contact'] = __( 'İletişim', 'listingpro' );
-
         $preferred_menu_order = array(
             'home'    => __( 'Anasayfa', 'listingpro' ),
             'about'   => __( 'Hakkımızda', 'listingpro' ),
@@ -701,6 +732,15 @@ if ( have_posts() ) {
         .lp-quick-actions a:hover{background:#e2e8f0;color:#005f99;box-shadow:0 10px 24px rgba(15,23,42,0.12);}
         .lp-quick-actions i{font-size:16px;}
         </style>
+        <?php
+        if ( $has_map && ! isset( $menu_items['map'] ) && in_array( 'lp_mapsocial_section', $layout_sections, true ) ) {
+            $menu_items['map'] = __( 'Harita', 'listingpro' );
+        }
+        if ( $has_hours && ! isset( $menu_items['hours'] ) && in_array( 'lp_timing_section', $layout_sections, true ) ) {
+            $menu_items['hours'] = __( 'Çalışma Saatleri', 'listingpro' );
+        }
+        $menu_items['contact'] = __( 'İletişim', 'listingpro' );
+        ?>
         <div class="lp-onepage-wrapper">
         <header class="lp-onepage-header">
             <div class="container lp-onepage-header-inner">

--- a/templates/listing-onepage.php
+++ b/templates/listing-onepage.php
@@ -1,28 +1,51 @@
 <?php
 /* One-page listing detail template */
+if ( ! function_exists( 'lp_onepage_meta' ) ) {
+    function lp_onepage_meta( $key, $post_id = null ) {
+        $id = $post_id ? $post_id : get_the_ID();
+
+        if ( function_exists( 'listing_get_metabox' ) ) {
+            $value = listing_get_metabox( $key );
+            if ( null !== $value && '' !== $value ) {
+                return $value;
+            }
+        }
+
+        if ( function_exists( 'listingpro_get_metabox' ) ) {
+            $value = listingpro_get_metabox( $key );
+            if ( null !== $value && '' !== $value ) {
+                return $value;
+            }
+        }
+
+        return get_post_meta( $id, $key, true );
+    }
+}
+
+if ( ! function_exists( 'lp_onepage_meta_by_id' ) ) {
+    function lp_onepage_meta_by_id( $key, $post_id ) {
+        if ( function_exists( 'listing_get_metabox_by_ID' ) ) {
+            $value = listing_get_metabox_by_ID( $key, $post_id );
+            if ( null !== $value && '' !== $value ) {
+                return $value;
+            }
+        }
+
+        if ( function_exists( 'listingpro_get_metabox_by_ID' ) ) {
+            $value = listingpro_get_metabox_by_ID( $key, $post_id );
+            if ( null !== $value && '' !== $value ) {
+                return $value;
+            }
+        }
+
+        return get_post_meta( $post_id, $key, true );
+    }
+}
+
 if ( have_posts() ) {
     while ( have_posts() ) {
         the_post();
         global $listingpro_options;
-
-        if ( ! function_exists( 'lp_onepage_meta' ) ) {
-            function lp_onepage_meta( $key, $post_id = null ) {
-                $id = $post_id ? $post_id : get_the_ID();
-                if ( function_exists( 'listingpro_get_metabox' ) ) {
-                    return listingpro_get_metabox( $key );
-                }
-                return get_post_meta( $id, $key, true );
-            }
-        }
-
-        if ( ! function_exists( 'lp_onepage_meta_by_id' ) ) {
-            function lp_onepage_meta_by_id( $key, $post_id ) {
-                if ( function_exists( 'listing_get_metabox_by_ID' ) ) {
-                    return listing_get_metabox_by_ID( $key, $post_id );
-                }
-                return get_post_meta( $post_id, $key, true );
-            }
-        }
 
         if ( ! function_exists( 'lp_onepage_on' ) ) {
             function lp_onepage_on( $flag ) {

--- a/templates/listing-onepage.php
+++ b/templates/listing-onepage.php
@@ -203,7 +203,7 @@ if ( have_posts() ) {
 
         $sections_markup = array();
         $menu_items      = array( 'home' => __( 'Anasayfa', 'listingpro' ) );
-
+        
         foreach ( $layout_general as $section_key ) {
             switch ( $section_key ) {
                 case 'lp_content_section':
@@ -567,6 +567,48 @@ if ( have_posts() ) {
             $menu_items['hours'] = __( 'Çalışma Saatleri', 'listingpro' );
         }
         $menu_items['contact'] = __( 'İletişim', 'listingpro' );
+
+        $preferred_menu_order = array(
+            'home'    => __( 'Anasayfa', 'listingpro' ),
+            'about'   => __( 'Hakkımızda', 'listingpro' ),
+            'services'=> __( 'Hizmetler', 'listingpro' ),
+            'video'   => __( 'Video', 'listingpro' ),
+            'gallery' => __( 'Resim', 'listingpro' ),
+            'reviews' => __( 'Yorumlar', 'listingpro' ),
+            'hours'   => __( 'Çalışma Saatleri', 'listingpro' ),
+            'contact' => __( 'İletişim', 'listingpro' ),
+        );
+
+        $filtered_menu = array();
+        foreach ( $preferred_menu_order as $slug => $label ) {
+            if ( 'home' === $slug ) {
+                $filtered_menu[ $slug ] = $label;
+                continue;
+            }
+
+            if ( 'hours' === $slug ) {
+                if ( $has_hours ) {
+                    $filtered_menu[ $slug ] = $label;
+                }
+                continue;
+            }
+
+            if ( isset( $menu_items[ $slug ] ) ) {
+                $filtered_menu[ $slug ] = $menu_items[ $slug ];
+            }
+        }
+
+        $menu_items = $filtered_menu;
+
+        $preferred_section_order = array( 'about', 'services', 'video', 'gallery', 'reviews' );
+        $ordered_sections        = array();
+        foreach ( $preferred_section_order as $section_slug ) {
+            if ( isset( $sections_markup[ $section_slug ] ) ) {
+                $ordered_sections[ $section_slug ] = $sections_markup[ $section_slug ];
+                unset( $sections_markup[ $section_slug ] );
+            }
+        }
+        $sections_markup = $ordered_sections + $sections_markup;
 
         $b_logo       = $listingpro_options['business_logo_switch'];
         $allow_logo   = isset( $listingpro_options['listingpro_allow_logo_styles_switch'] ) ? $listingpro_options['listingpro_allow_logo_styles_switch'] : '';

--- a/templates/listing-onepage.php
+++ b/templates/listing-onepage.php
@@ -357,26 +357,17 @@ if ( have_posts() ) {
                     if ( ! lp_onepage_on( $gallery_show ) || empty( $gallery_ids ) || isset( $sections_markup['gallery'] ) ) {
                         break;
                     }
+                    $gallery_markup = lp_onepage_capture( 'templates/single-list/listing-details-style4/content/gallery.php' );
+                    if ( empty( $gallery_markup ) ) {
+                        break;
+                    }
                     ob_start();
                     ?>
                     <section id="gallery" class="lp-section lp-section-gallery">
                         <div class="container">
                             <h2 class="lp-section-title"><?php echo esc_html__( 'Resim', 'listingpro' ); ?></h2>
-                            <div class="lp-gallery-grid">
-                                <?php foreach ( $gallery_ids as $img_id ) :
-                                    $full = wp_get_attachment_image_src( $img_id, 'full' );
-                                    if ( empty( $full[0] ) ) {
-                                        continue;
-                                    }
-                                    $thumb = wp_get_attachment_image( $img_id, 'large', false, array( 'class' => 'lp-gallery-thumb' ) );
-                                    if ( empty( $thumb ) ) {
-                                        $thumb = '<img class="lp-gallery-thumb" src="' . esc_url( $full[0] ) . '" alt="' . esc_attr( $lp_title ) . '" />';
-                                    }
-                                    ?>
-                                    <a class="lp-gallery-item" href="<?php echo esc_url( $full[0] ); ?>" rel="prettyPhoto[gallery1]">
-                                        <?php echo $thumb; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-                                    </a>
-                                <?php endforeach; ?>
+                            <div class="lp-gallery-slider-wrap">
+                                <?php echo $gallery_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
                             </div>
                         </div>
                     </section>
@@ -748,10 +739,12 @@ if ( have_posts() ) {
         .lp-section-title{margin:0 0 36px;font-size:32px;font-weight:700;text-align:center;color:#0f172a;}
         .lp-services-list{list-style:none;margin:0 auto;max-width:780px;padding:0;display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:14px;text-align:center;}
         .lp-services-list li{background:#fff;border-radius:14px;padding:16px 18px;font-weight:600;color:#1f2937;box-shadow:0 14px 30px rgba(15,23,42,0.08);}
-        .lp-gallery-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:22px;}
-        .lp-gallery-item{display:block;overflow:hidden;border-radius:16px;box-shadow:0 18px 36px rgba(15,23,42,0.12);transition:transform .3s ease,box-shadow .3s ease;}
-        .lp-gallery-item:hover{transform:translateY(-6px);box-shadow:0 24px 44px rgba(15,23,42,0.16);}
-        .lp-gallery-thumb{width:100%;height:100%;object-fit:cover;display:block;}
+        .lp-gallery-slider-wrap{position:relative;}
+        .lp-gallery-slider-wrap .lp-listing-slider{margin:0 auto;}
+        .lp-gallery-slider-wrap .lp-listing-slider .slick-list{margin:0 -12px;}
+        .lp-gallery-slider-wrap .lp-listing-slide-wrap{padding:0 12px;}
+        .lp-gallery-slider-wrap .lp-listing-slide{border-radius:18px;overflow:hidden;box-shadow:0 18px 36px rgba(15,23,42,0.12);}
+        .lp-gallery-slider-wrap .lp-listing-slide img{width:100%;height:auto;display:block;}
         .lp-video-wrapper{position:relative;padding-bottom:56.25%;height:0;overflow:hidden;border-radius:18px;box-shadow:0 16px 36px rgba(15,23,42,0.18);}
         .lp-video-wrapper iframe{position:absolute;top:0;left:0;width:100%;height:100%;border:0;border-radius:18px;}
         #singlepostmap{width:100%;height:360px;border-radius:16px;box-shadow:0 18px 40px rgba(15,23,42,0.1);}

--- a/templates/listing-onepage.php
+++ b/templates/listing-onepage.php
@@ -174,69 +174,33 @@ if ( have_posts() ) {
         $announcements_raw = get_post_meta( get_the_ID(), 'lp_listing_announcements', true );
         $has_announcements = is_array( $announcements_raw ) && count( $announcements_raw ) > 0;
 
-        foreach ( $layout_general as $section_key ) {
-            switch ( $section_key ) {
-                case 'lp_content_section':
-                    if ( ! empty( $description ) ) {
-                        $menu_items['about'] = __( 'Hakkımızda', 'listingpro' );
-                    }
-                    break;
-                case 'lp_services_section':
-                    if ( ! empty( $service_names ) ) {
-                        $menu_items['services'] = __( 'Hizmetler', 'listingpro' );
-                    }
-                    break;
-                case 'lp_gallery_section':
-                    if ( lp_onepage_on( $gallery_show ) && ! empty( $gallery_ids ) ) {
-                        $menu_items['gallery'] = __( 'Resim', 'listingpro' );
-                    }
-                    break;
-                case 'lp_video_section':
-                    if ( ! empty( $video_html ) ) {
-                        $menu_items['video'] = __( 'Video', 'listingpro' );
-                    }
-                    break;
-                case 'lp_faqs_section':
-                    if ( lp_onepage_on( $faqs_show ) && $has_faq ) {
-                        $menu_items['faq'] = __( 'SSS', 'listingpro' );
-                    }
-                    break;
-                case 'lp_announcements_section':
-                    if ( $has_announcements ) {
-                        $menu_items['announcements'] = __( 'Duyurular', 'listingpro' );
-                    }
-                    break;
-                case 'lp_menu_section':
-                    if ( $menuOption ) {
-                        $menu_items['menu'] = __( 'Menü', 'listingpro' );
-                    }
-                    break;
-                case 'lp_event_section':
-                    $menu_items['event'] = __( 'Etkinlikler', 'listingpro' );
-                    break;
-                case 'lp_reviews_section':
-                    $menu_items['reviews'] = __( 'Yorumlar', 'listingpro' );
-                    break;
-                case 'lp_features_section':
-                    $menu_items['features'] = __( 'Özellikler', 'listingpro' );
-                    break;
-                case 'lp_booking_section':
-                    if ( $timekit || ! empty( $resurva_url ) || class_exists( 'Listingpro_bookings' ) ) {
-                        $menu_items['booking'] = __( 'Randevu', 'listingpro' );
-                    }
-                    break;
-            }
-        }
+        $enabled_sections = array_flip( $layout_general );
 
-        if ( lp_onepage_on( $map_show ) && ! empty( $latitude ) && ! empty( $longitude ) ) {
-            $menu_items['map'] = __( 'Harita', 'listingpro' );
+        $has_about    = isset( $enabled_sections['lp_content_section'] ) && ! empty( $description );
+        $has_services = isset( $enabled_sections['lp_services_section'] ) && ! empty( $service_names );
+        $has_features = isset( $enabled_sections['lp_features_section'] ) && ! empty( $service_names );
+        $has_features_section = $has_features || $has_services;
+        $has_gallery  = isset( $enabled_sections['lp_gallery_section'] ) && lp_onepage_on( $gallery_show ) && ! empty( $gallery_ids );
+        $has_video    = isset( $enabled_sections['lp_video_section'] ) && ! empty( $video_html );
+        $has_reviews  = isset( $enabled_sections['lp_reviews_section'] );
+        $has_map      = lp_onepage_on( $map_show ) && ! empty( $latitude ) && ! empty( $longitude );
+        $has_hours    = lp_onepage_on( $hours_show ) && ( is_array( $hours ) ? ! empty( array_filter( $hours ) ) : ! empty( $hours ) );
+
+        $menu_items = array( 'home' => __( 'Anasayfa', 'listingpro' ) );
+        if ( $has_about ) {
+            $menu_items['about'] = __( 'Hakkımızda', 'listingpro' );
         }
-        $has_hours = ! empty( $hours );
-        if ( is_array( $hours ) ) {
-            $has_hours = ! empty( array_filter( $hours ) );
+        if ( $has_features_section ) {
+            $menu_items['features'] = __( 'Özellikler', 'listingpro' );
         }
-        if ( lp_onepage_on( $hours_show ) && $has_hours ) {
-            $menu_items['hours'] = __( 'Çalışma Saatleri', 'listingpro' );
+        if ( $has_gallery ) {
+            $menu_items['gallery'] = __( 'Resim', 'listingpro' );
+        }
+        if ( $has_video ) {
+            $menu_items['video'] = __( 'Video', 'listingpro' );
+        }
+        if ( $has_reviews ) {
+            $menu_items['reviews'] = __( 'Yorumlar', 'listingpro' );
         }
         $menu_items['contact'] = __( 'İletişim', 'listingpro' );
 
@@ -352,84 +316,93 @@ if ( have_posts() ) {
         </div>
         <?php endif; ?>
 
-        <?php foreach ( $layout_general as $section_key ) {
+        <?php if ( $has_about ) : ?>
+            <section id="about" class="lp-section lp-section-about">
+                <div class="container">
+                    <h2 class="lp-section-title"><?php echo esc_html( $menu_items['about'] ); ?></h2>
+                    <?php echo apply_filters( 'the_content', $description ); ?>
+                </div>
+            </section>
+        <?php endif; ?>
+
+        <?php if ( $has_features_section ) : ?>
+            <section id="features" class="lp-section lp-section-features">
+                <div class="container">
+                    <h2 class="lp-section-title"><?php echo esc_html( $menu_items['features'] ); ?></h2>
+                    <?php
+                    if ( $has_features ) {
+                        get_template_part( 'templates/single-list/listing-details-style6/content/features' );
+                    } elseif ( $has_services ) {
+                        ?>
+                        <ul class="lp-services-list">
+                            <?php foreach ( $service_names as $service_name ) : ?>
+                                <li><?php echo esc_html( $service_name ); ?></li>
+                            <?php endforeach; ?>
+                        </ul>
+                        <?php
+                    }
+                    ?>
+                </div>
+            </section>
+        <?php endif; ?>
+
+        <?php if ( $has_gallery ) : ?>
+            <section id="gallery" class="lp-section lp-section-gallery">
+                <div class="container">
+                    <h2 class="lp-section-title"><?php echo esc_html( $menu_items['gallery'] ); ?></h2>
+                    <?php if ( ! empty( $gallery_ids ) ) : ?>
+                        <div class="lp-gallery-grid">
+                            <?php
+                            foreach ( $gallery_ids as $img_id ) {
+                                $full = wp_get_attachment_image_src( $img_id, 'full' );
+                                if ( empty( $full[0] ) ) {
+                                    continue;
+                                }
+                                $thumb = wp_get_attachment_image( $img_id, 'large', false, array( 'class' => 'lp-gallery-thumb' ) );
+                                if ( empty( $thumb ) ) {
+                                    $thumb = '<img class="lp-gallery-thumb" src="' . esc_url( $full[0] ) . '" alt="' . esc_attr( $lp_title ) . '" />';
+                                }
+                                echo '<a class="lp-gallery-item" href="' . esc_url( $full[0] ) . '" rel="prettyPhoto[gallery1]">' . $thumb . '</a>';
+                            }
+                            ?>
+                        </div>
+                    <?php endif; ?>
+                </div>
+            </section>
+        <?php endif; ?>
+
+        <?php if ( $has_video ) : ?>
+            <section id="video" class="lp-section lp-section-video">
+                <div class="container">
+                    <h2 class="lp-section-title"><?php echo esc_html( $menu_items['video'] ); ?></h2>
+                    <div class="lp-video-wrapper">
+                        <?php echo wp_kses( $video_html, array_merge( wp_kses_allowed_html( 'post' ), array( 'iframe' => array( 'src' => true, 'width' => true, 'height' => true, 'frameborder' => true, 'allowfullscreen' => true ) ) ) ); ?>
+                    </div>
+                </div>
+            </section>
+        <?php endif; ?>
+
+        <?php if ( $has_reviews ) : ?>
+            <section id="reviews" class="lp-section lp-section-reviews">
+                <div class="container">
+                    <h2 class="lp-section-title"><?php echo esc_html( $menu_items['reviews'] ); ?></h2>
+                    <?php get_template_part( 'templates/single-list/listing-details-style6/content/reviews' ); ?>
+                </div>
+            </section>
+        <?php endif; ?>
+
+        <?php
+        foreach ( $layout_general as $section_key ) {
+            if ( in_array( $section_key, array( 'lp_content_section', 'lp_services_section', 'lp_gallery_section', 'lp_video_section', 'lp_reviews_section', 'lp_features_section' ), true ) ) {
+                continue;
+            }
             switch ( $section_key ) {
-                case 'lp_content_section':
-                    if ( isset( $menu_items['about'] ) ) {
-                        ?>
-                        <section id="about" class="lp-section lp-section-about">
-                            <div class="container">
-                                <h2 class="lp-section-title"><?php echo esc_html( $menu_items['about'] ); ?></h2>
-                                <?php echo apply_filters( 'the_content', $description ); ?>
-                            </div>
-                        </section>
-                        <?php
-                    }
-                    break;
-                case 'lp_services_section':
-                    if ( isset( $menu_items['services'] ) ) {
-                        ?>
-                        <section id="services" class="lp-section lp-section-services">
-                            <div class="container">
-                                <h2 class="lp-section-title"><?php echo esc_html( $menu_items['services'] ); ?></h2>
-                                <ul class="lp-services-list">
-                                <?php foreach ( $service_names as $service_name ) : ?>
-                                    <li><?php echo esc_html( $service_name ); ?></li>
-                                <?php endforeach; ?>
-                                </ul>
-                            </div>
-                        </section>
-                        <?php
-                    }
-                    break;
-                case 'lp_gallery_section':
-                    if ( isset( $menu_items['gallery'] ) ) {
-                        ?>
-                        <section id="gallery" class="lp-section lp-section-gallery">
-                            <div class="container">
-                                <h2 class="lp-section-title"><?php echo esc_html( $menu_items['gallery'] ); ?></h2>
-                                <?php if ( ! empty( $gallery_ids ) ) : ?>
-                                    <div class="lp-gallery-grid">
-                                        <?php
-                                        foreach ( $gallery_ids as $img_id ) {
-                                            $full = wp_get_attachment_image_src( $img_id, 'full' );
-                                            if ( empty( $full[0] ) ) {
-                                                continue;
-                                            }
-                                            $thumb = wp_get_attachment_image( $img_id, 'large', false, array( 'class' => 'lp-gallery-thumb' ) );
-                                            if ( empty( $thumb ) ) {
-                                                $thumb = '<img class="lp-gallery-thumb" src="' . esc_url( $full[0] ) . '" alt="' . esc_attr( $lp_title ) . '" />';
-                                            }
-                                            echo '<a class="lp-gallery-item" href="' . esc_url( $full[0] ) . '" rel="prettyPhoto[gallery1]">' . $thumb . '</a>';
-                                        }
-                                        ?>
-                                    </div>
-                                <?php endif; ?>
-                            </div>
-                        </section>
-                        <?php
-                    }
-                    break;
-                case 'lp_video_section':
-                    if ( isset( $menu_items['video'] ) ) {
-                        ?>
-                        <section id="video" class="lp-section lp-section-video">
-                            <div class="container">
-                                <h2 class="lp-section-title"><?php echo esc_html( $menu_items['video'] ); ?></h2>
-                                <div class="lp-video-wrapper">
-                                <?php echo wp_kses( $video_html, array_merge( wp_kses_allowed_html( 'post' ), array( 'iframe' => array( 'src' => true, 'width' => true, 'height' => true, 'frameborder' => true, 'allowfullscreen' => true ) ) ) ); ?>
-                                </div>
-                            </div>
-                        </section>
-                        <?php
-                    }
-                    break;
                 case 'lp_faqs_section':
-                    if ( isset( $menu_items['faq'] ) ) {
+                    if ( lp_onepage_on( $faqs_show ) && $has_faq ) {
                         ?>
                         <section id="faq" class="lp-section lp-section-faq">
                             <div class="container">
-                                <h2 class="lp-section-title"><?php echo esc_html( $menu_items['faq'] ); ?></h2>
+                                <h2 class="lp-section-title"><?php echo esc_html__( 'SSS', 'listingpro' ); ?></h2>
                                 <?php get_template_part( 'templates/single-list/listing-details-style4/content/list-faq' ); ?>
                             </div>
                         </section>
@@ -437,11 +410,11 @@ if ( have_posts() ) {
                     }
                     break;
                 case 'lp_announcements_section':
-                    if ( isset( $menu_items['announcements'] ) ) {
+                    if ( $has_announcements ) {
                         ?>
                         <section id="announcements" class="lp-section lp-section-announcements">
                             <div class="container">
-                                <h2 class="lp-section-title"><?php echo esc_html( $menu_items['announcements'] ); ?></h2>
+                                <h2 class="lp-section-title"><?php echo esc_html__( 'Duyurular', 'listingpro' ); ?></h2>
                                 <?php get_template_part( 'templates/single-list/listing-details-style6/content/list-announcements' ); ?>
                             </div>
                         </section>
@@ -449,55 +422,19 @@ if ( have_posts() ) {
                     }
                     break;
                 case 'lp_menu_section':
-                    if ( isset( $menu_items['menu'] ) ) {
+                    if ( $menuOption ) {
                         ?>
                         <section id="menu" class="lp-section lp-section-menu">
                             <div class="container">
-                                <h2 class="lp-section-title"><?php echo esc_html( $menu_items['menu'] ); ?></h2>
+                                <h2 class="lp-section-title"><?php echo esc_html__( 'Menü', 'listingpro' ); ?></h2>
                                 <?php get_template_part( 'templates/single-list/listing-details-style6/content/list-menu' ); ?>
                             </div>
                         </section>
                         <?php
                     }
                     break;
-                case 'lp_event_section':
-                    if ( isset( $menu_items['event'] ) ) {
-                        ?>
-                        <section id="event" class="lp-section lp-section-event">
-                            <div class="container">
-                                <h2 class="lp-section-title"><?php echo esc_html( $menu_items['event'] ); ?></h2>
-                                <?php $GLOBALS['event_grid_call'] = 'content_area'; get_template_part( 'templates/single-list/event' ); ?>
-                            </div>
-                        </section>
-                        <?php
-                    }
-                    break;
-                case 'lp_reviews_section':
-                    if ( isset( $menu_items['reviews'] ) ) {
-                        ?>
-                        <section id="reviews" class="lp-section lp-section-reviews">
-                            <div class="container">
-                                <h2 class="lp-section-title"><?php echo esc_html( $menu_items['reviews'] ); ?></h2>
-                                <?php get_template_part( 'templates/single-list/listing-details-style6/content/reviews' ); ?>
-                            </div>
-                        </section>
-                        <?php
-                    }
-                    break;
-                case 'lp_features_section':
-                    if ( isset( $menu_items['features'] ) ) {
-                        ?>
-                        <section id="features" class="lp-section lp-section-features">
-                            <div class="container">
-                                <h2 class="lp-section-title"><?php echo esc_html( $menu_items['features'] ); ?></h2>
-                                <?php get_template_part( 'templates/single-list/listing-details-style6/content/features' ); ?>
-                            </div>
-                        </section>
-                        <?php
-                    }
-                    break;
                 case 'lp_booking_section':
-                    if ( isset( $menu_items['booking'] ) ) {
+                    if ( $timekit || ! empty( $resurva_url ) || class_exists( 'Listingpro_bookings' ) ) {
                         ?>
                         <section id="booking" class="lp-section lp-section-booking">
                             <div class="container">
@@ -526,20 +463,20 @@ if ( have_posts() ) {
         }
         ?>
 
-        <?php if ( isset( $menu_items['map'] ) ) :
+        <?php if ( $has_map ) :
             $lp_map_pin = $listingpro_options['lp_map_pin']['url']; ?>
             <section id="map" class="lp-section lp-section-map">
                 <div class="container">
-                    <h2 class="lp-section-title"><?php echo esc_html( $menu_items['map'] ); ?></h2>
+                    <h2 class="lp-section-title"><?php echo esc_html__( 'Harita', 'listingpro' ); ?></h2>
                     <div id="singlepostmap" class="singlemap" data-lat="<?php echo esc_attr( $latitude ); ?>" data-lan="<?php echo esc_attr( $longitude ); ?>" data-pinicon="<?php echo esc_attr( $lp_map_pin ); ?>"></div>
                 </div>
             </section>
         <?php endif; ?>
 
-        <?php if ( isset( $menu_items['hours'] ) ) : ?>
+        <?php if ( $has_hours ) : ?>
             <section id="hours" class="lp-section lp-section-hours">
                 <div class="container">
-                    <h2 class="lp-section-title"><?php echo esc_html( $menu_items['hours'] ); ?></h2>
+                    <h2 class="lp-section-title"><?php echo esc_html__( 'Çalışma Saatleri', 'listingpro' ); ?></h2>
                     <?php get_template_part( 'include/timings' ); ?>
                 </div>
             </section>

--- a/templates/listing-onepage.php
+++ b/templates/listing-onepage.php
@@ -288,8 +288,9 @@ if ( have_posts() ) {
         $has_map   = ! empty( $latitude ) && ! empty( $longitude );
         $has_hours = is_array( $hours ) ? ! empty( array_filter( $hours ) ) : ! empty( $hours );
 
-        $sections_markup = array();
-        $menu_items      = array();
+        $sections_markup      = array();
+        $menu_items           = array();
+        $has_gallery_slider   = false;
         
         foreach ( $layout_sections as $section_key ) {
             switch ( $section_key ) {
@@ -356,8 +357,23 @@ if ( have_posts() ) {
                     if ( ! lp_onepage_on( $gallery_show ) || empty( $gallery_ids ) || isset( $sections_markup['gallery'] ) ) {
                         break;
                     }
-                    $gallery_markup = lp_onepage_capture( 'templates/single-list/listing-details-style4/content/gallery.php' );
-                    if ( empty( $gallery_markup ) ) {
+                    $gallery_slides = array();
+                    foreach ( $gallery_ids as $img_id ) {
+                        $full  = wp_get_attachment_image_src( $img_id, 'full' );
+                        $thumb = wp_get_attachment_image( $img_id, 'large', false, array( 'class' => 'lp-gallery-slide-image' ) );
+                        if ( empty( $full[0] ) ) {
+                            continue;
+                        }
+                        if ( empty( $thumb ) ) {
+                            $thumb = '<img class="lp-gallery-slide-image" src="' . esc_url( $full[0] ) . '" alt="' . esc_attr( get_the_title() ) . '" />';
+                        }
+                        $gallery_slides[] = sprintf(
+                            '<div class="lp-gallery-slide"><a href="%1$s" rel="prettyPhoto[gallery1]">%2$s</a></div>',
+                            esc_url( $full[0] ),
+                            $thumb
+                        );
+                    }
+                    if ( empty( $gallery_slides ) ) {
                         break;
                     }
                     ob_start();
@@ -365,14 +381,15 @@ if ( have_posts() ) {
                     <section id="gallery" class="lp-section lp-section-gallery">
                         <div class="container">
                             <h2 class="lp-section-title"><?php echo esc_html__( 'Resim', 'listingpro' ); ?></h2>
-                            <div class="lp-gallery-slider-wrap">
-                                <?php echo $gallery_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                            <div class="lp-gallery-slider js-lp-gallery-slider">
+                                <?php echo implode( '', $gallery_slides ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
                             </div>
                         </div>
                     </section>
                     <?php
                     $sections_markup['gallery'] = ob_get_clean();
                     $menu_items['gallery']      = __( 'Resim', 'listingpro' );
+                    $has_gallery_slider         = true;
                     break;
 
                 case 'lp_sidebar_video':
@@ -711,12 +728,16 @@ if ( have_posts() ) {
         .lp-section-title{margin:0 0 36px;font-size:32px;font-weight:700;text-align:center;color:#0f172a;}
         .lp-services-list{list-style:none;margin:0 auto;max-width:780px;padding:0;display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:14px;text-align:center;}
         .lp-services-list li{background:#fff;border-radius:14px;padding:16px 18px;font-weight:600;color:#1f2937;box-shadow:0 14px 30px rgba(15,23,42,0.08);}
-        .lp-gallery-slider-wrap{position:relative;}
-        .lp-gallery-slider-wrap .lp-listing-slider{margin:0 auto;}
-        .lp-gallery-slider-wrap .lp-listing-slider .slick-list{margin:0 -12px;}
-        .lp-gallery-slider-wrap .lp-listing-slide-wrap{padding:0 12px;}
-        .lp-gallery-slider-wrap .lp-listing-slide{border-radius:18px;overflow:hidden;box-shadow:0 18px 36px rgba(15,23,42,0.12);}
-        .lp-gallery-slider-wrap .lp-listing-slide img{width:100%;height:auto;display:block;}
+        .lp-gallery-slider{position:relative;}
+        .lp-gallery-slide{padding:12px;}
+        .lp-gallery-slide a{display:block;border-radius:18px;overflow:hidden;box-shadow:0 20px 36px rgba(15,23,42,0.16);transition:transform .3s ease,box-shadow .3s ease;}
+        .lp-gallery-slide a:hover{transform:translateY(-6px);box-shadow:0 26px 48px rgba(15,23,42,0.24);}
+        .lp-gallery-slide-image{display:block;width:100%;height:260px;object-fit:cover;}
+        .lp-gallery-slider .slick-arrow{width:44px;height:44px;background:#fff;border-radius:50%;box-shadow:0 12px 28px rgba(15,23,42,0.16);z-index:2;}
+        .lp-gallery-slider .slick-arrow::before{color:#0f172a;font-size:18px;}
+        .lp-gallery-slider .slick-dots{bottom:-36px;}
+        .lp-gallery-slider .slick-dots li button:before{font-size:12px;color:#94a3b8;opacity:1;}
+        .lp-gallery-slider .slick-dots li.slick-active button:before{color:#2563eb;}
         .lp-video-wrapper{position:relative;padding-bottom:56.25%;height:0;overflow:hidden;border-radius:18px;box-shadow:0 16px 36px rgba(15,23,42,0.18);}
         .lp-video-wrapper iframe{position:absolute;top:0;left:0;width:100%;height:100%;border:0;border-radius:18px;}
         #singlepostmap{width:100%;height:360px;border-radius:16px;box-shadow:0 18px 40px rgba(15,23,42,0.1);}
@@ -973,6 +994,34 @@ if ( have_posts() ) {
             var $toggle  = $('.lp-menu-toggle');
             var $nav     = $('.lp-onepage-nav');
             var headerGap = 14;
+
+<?php if ( $has_gallery_slider ) : ?>
+            var $gallerySlider = $('.js-lp-gallery-slider');
+            if ( $gallerySlider.length && $.fn.slick ) {
+                $gallerySlider.not('.slick-initialized').slick({
+                    slidesToShow: 3,
+                    slidesToScroll: 1,
+                    dots: true,
+                    arrows: true,
+                    adaptiveHeight: true,
+                    responsive: [
+                        {
+                            breakpoint: 1200,
+                            settings: {
+                                slidesToShow: 2
+                            }
+                        },
+                        {
+                            breakpoint: 768,
+                            settings: {
+                                slidesToShow: 1
+                            }
+                        }
+                    ]
+                });
+            }
+
+<?php endif; ?>
 
             function getHeaderOffset() {
                 return $header.length ? $header.outerHeight() + headerGap : headerGap;

--- a/templates/listing-onepage.php
+++ b/templates/listing-onepage.php
@@ -31,7 +31,7 @@ if ( have_posts() ) {
         }
 
         if ( ! function_exists( 'lp_onepage_capture' ) ) {
-            function lp_onepage_capture( $template ) {
+            function lp_onepage_capture( $template, $vars = array() ) {
                 $template_path = locate_template( $template, false, false );
                 if ( empty( $template_path ) ) {
                     return '';
@@ -45,12 +45,22 @@ if ( have_posts() ) {
                     $post = get_post( get_the_ID() );
                 }
 
+                if ( ! empty( $vars ) && is_array( $vars ) ) {
+                    extract( $vars, EXTR_SKIP );
+                }
+
                 include $template_path;
 
                 $post = $original_post;
 
                 return trim( ob_get_clean() );
             }
+        }
+
+        $currentUserId = get_current_user_id();
+        $showReport    = true;
+        if ( isset( $listingpro_options['lp_detail_page_report_button'] ) && 'off' === $listingpro_options['lp_detail_page_report_button'] ) {
+            $showReport = false;
         }
 
         if ( ! function_exists( 'lp_onepage_collect_keys' ) ) {
@@ -557,7 +567,13 @@ if ( have_posts() ) {
                     if ( isset( $sections_markup['quick'] ) ) {
                         break;
                     }
-                    $quicks_markup = lp_onepage_capture( 'templates/single-list/listing-details-style4/sidebar/quicks.php' );
+                    $quicks_markup = lp_onepage_capture(
+                        'templates/single-list/listing-details-style4/sidebar/quicks.php',
+                        array(
+                            'currentUserId' => $currentUserId,
+                            'showReport'    => $showReport,
+                        )
+                    );
                     if ( empty( $quicks_markup ) ) {
                         break;
                     }

--- a/templates/listing-onepage.php
+++ b/templates/listing-onepage.php
@@ -40,7 +40,14 @@ if ( have_posts() ) {
                 ob_start();
 
                 global $post;
+                $original_post = $post;
+                if ( ! ( $post instanceof WP_Post ) ) {
+                    $post = get_post( get_the_ID() );
+                }
+
                 include $template_path;
+
+                $post = $original_post;
 
                 return trim( ob_get_clean() );
             }

--- a/templates/listing-onepage.php
+++ b/templates/listing-onepage.php
@@ -30,11 +30,29 @@ if ( have_posts() ) {
             }
         }
 
+        if ( ! function_exists( 'lp_onepage_capture' ) ) {
+            function lp_onepage_capture( $template ) {
+                $template_path = locate_template( $template, false, false );
+                if ( empty( $template_path ) ) {
+                    return '';
+                }
+
+                ob_start();
+                $include_result = include $template_path;
+                $html_output    = ob_get_clean();
+
+                if ( false === $include_result ) {
+                    return '';
+                }
+
+                return trim( $html_output );
+            }
+        }
+
         $layout_general = isset( $listingpro_options['lp-detail-page-layout6-content']['general'] )
             ? array_keys( $listingpro_options['lp-detail-page-layout6-content']['general'] )
             : array( 'lp_content_section', 'lp_services_section', 'lp_gallery_section', 'lp_video_section', 'lp_faqs_section' );
 
-        $menu_items = array( 'home' => __( 'Anasayfa', 'listingpro' ) );
         $description = lp_onepage_meta( 'lp_listing_description' );
         if ( empty( $description ) ) {
             $description = get_post_field( 'post_content', get_the_ID() );
@@ -176,32 +194,368 @@ if ( have_posts() ) {
 
         $enabled_sections = array_flip( $layout_general );
 
-        $has_about    = isset( $enabled_sections['lp_content_section'] ) && ! empty( $description );
-        $has_services = isset( $enabled_sections['lp_services_section'] ) && ! empty( $service_names );
-        $has_features = isset( $enabled_sections['lp_features_section'] ) && ! empty( $service_names );
-        $has_features_section = $has_features || $has_services;
-        $has_gallery  = isset( $enabled_sections['lp_gallery_section'] ) && lp_onepage_on( $gallery_show ) && ! empty( $gallery_ids );
-        $has_video    = isset( $enabled_sections['lp_video_section'] ) && ! empty( $video_html );
-        $has_reviews  = isset( $enabled_sections['lp_reviews_section'] );
-        $has_map      = lp_onepage_on( $map_show ) && ! empty( $latitude ) && ! empty( $longitude );
-        $has_hours    = lp_onepage_on( $hours_show ) && ( is_array( $hours ) ? ! empty( array_filter( $hours ) ) : ! empty( $hours ) );
+        $has_map   = lp_onepage_on( $map_show ) && ! empty( $latitude ) && ! empty( $longitude );
+        $has_hours = lp_onepage_on( $hours_show ) && ( is_array( $hours ) ? ! empty( array_filter( $hours ) ) : ! empty( $hours ) );
 
-        $menu_items = array( 'home' => __( 'Anasayfa', 'listingpro' ) );
-        if ( $has_about ) {
-            $menu_items['about'] = __( 'Hakkımızda', 'listingpro' );
+        $sections_markup = array();
+        $menu_items      = array( 'home' => __( 'Anasayfa', 'listingpro' ) );
+
+        foreach ( $layout_general as $section_key ) {
+            switch ( $section_key ) {
+                case 'lp_content_section':
+                    if ( empty( $description ) || isset( $sections_markup['about'] ) ) {
+                        break;
+                    }
+                    ob_start();
+                    ?>
+                    <section id="about" class="lp-section lp-section-about">
+                        <div class="container">
+                            <h2 class="lp-section-title"><?php echo esc_html__( 'Hakkımızda', 'listingpro' ); ?></h2>
+                            <?php echo apply_filters( 'the_content', $description ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                        </div>
+                    </section>
+                    <?php
+                    $sections_markup['about'] = ob_get_clean();
+                    $menu_items['about']      = __( 'Hakkımızda', 'listingpro' );
+                    break;
+
+                case 'lp_services_section':
+                    if ( empty( $service_names ) || isset( $sections_markup['services'] ) ) {
+                        break;
+                    }
+                    ob_start();
+                    ?>
+                    <section id="services" class="lp-section lp-section-services">
+                        <div class="container">
+                            <h2 class="lp-section-title"><?php echo esc_html__( 'Hizmetler', 'listingpro' ); ?></h2>
+                            <ul class="lp-services-list">
+                                <?php foreach ( $service_names as $service_name ) : ?>
+                                    <li><?php echo esc_html( $service_name ); ?></li>
+                                <?php endforeach; ?>
+                            </ul>
+                        </div>
+                    </section>
+                    <?php
+                    $sections_markup['services'] = ob_get_clean();
+                    $menu_items['services']      = __( 'Hizmetler', 'listingpro' );
+                    break;
+
+                case 'lp_features_section':
+                    if ( isset( $sections_markup['features'] ) ) {
+                        break;
+                    }
+                    $features_html = lp_onepage_capture( 'templates/single-list/listing-details-style6/content/features.php' );
+                    if ( empty( $features_html ) ) {
+                        break;
+                    }
+                    ob_start();
+                    ?>
+                    <section id="features" class="lp-section lp-section-features">
+                        <div class="container">
+                            <h2 class="lp-section-title"><?php echo esc_html__( 'Özellikler', 'listingpro' ); ?></h2>
+                            <?php echo $features_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                        </div>
+                    </section>
+                    <?php
+                    $sections_markup['features'] = ob_get_clean();
+                    $menu_items['features']      = __( 'Özellikler', 'listingpro' );
+                    break;
+
+                case 'lp_gallery_section':
+                    if ( ! lp_onepage_on( $gallery_show ) || empty( $gallery_ids ) || isset( $sections_markup['gallery'] ) ) {
+                        break;
+                    }
+                    ob_start();
+                    ?>
+                    <section id="gallery" class="lp-section lp-section-gallery">
+                        <div class="container">
+                            <h2 class="lp-section-title"><?php echo esc_html__( 'Resim', 'listingpro' ); ?></h2>
+                            <div class="lp-gallery-grid">
+                                <?php foreach ( $gallery_ids as $img_id ) :
+                                    $full = wp_get_attachment_image_src( $img_id, 'full' );
+                                    if ( empty( $full[0] ) ) {
+                                        continue;
+                                    }
+                                    $thumb = wp_get_attachment_image( $img_id, 'large', false, array( 'class' => 'lp-gallery-thumb' ) );
+                                    if ( empty( $thumb ) ) {
+                                        $thumb = '<img class="lp-gallery-thumb" src="' . esc_url( $full[0] ) . '" alt="' . esc_attr( $lp_title ) . '" />';
+                                    }
+                                    ?>
+                                    <a class="lp-gallery-item" href="<?php echo esc_url( $full[0] ); ?>" rel="prettyPhoto[gallery1]">
+                                        <?php echo $thumb; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                                    </a>
+                                <?php endforeach; ?>
+                            </div>
+                        </div>
+                    </section>
+                    <?php
+                    $sections_markup['gallery'] = ob_get_clean();
+                    $menu_items['gallery']      = __( 'Resim', 'listingpro' );
+                    break;
+
+                case 'lp_video_section':
+                    if ( empty( $video_html ) || isset( $sections_markup['video'] ) ) {
+                        break;
+                    }
+                    ob_start();
+                    ?>
+                    <section id="video" class="lp-section lp-section-video">
+                        <div class="container">
+                            <h2 class="lp-section-title"><?php echo esc_html__( 'Video', 'listingpro' ); ?></h2>
+                            <div class="lp-video-wrapper">
+                                <?php echo wp_kses( $video_html, array_merge( wp_kses_allowed_html( 'post' ), array( 'iframe' => array(
+                                    'src' => true,
+                                    'width' => true,
+                                    'height' => true,
+                                    'frameborder' => true,
+                                    'allowfullscreen' => true,
+                                ) ) ) ); ?>
+                            </div>
+                        </div>
+                    </section>
+                    <?php
+                    $sections_markup['video'] = ob_get_clean();
+                    $menu_items['video']      = __( 'Video', 'listingpro' );
+                    break;
+
+                case 'lp_additional_section':
+                    if ( isset( $sections_markup['additional'] ) ) {
+                        break;
+                    }
+                    $additional_html = '';
+                    if ( function_exists( 'listing_all_extra_fields' ) ) {
+                        $additional_html = listing_all_extra_fields( get_the_ID() );
+                    }
+                    if ( empty( $additional_html ) && function_exists( 'listing_all_extra_fields_v2' ) ) {
+                        $additional_html = listing_all_extra_fields_v2( get_the_ID() );
+                    }
+                    if ( empty( $additional_html ) ) {
+                        break;
+                    }
+                    ob_start();
+                    ?>
+                    <section id="additional" class="lp-section lp-section-additional">
+                        <div class="container">
+                            <h2 class="lp-section-title"><?php echo esc_html__( 'Ek Bilgiler', 'listingpro' ); ?></h2>
+                            <?php echo $additional_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                        </div>
+                    </section>
+                    <?php
+                    $sections_markup['additional'] = ob_get_clean();
+                    $menu_items['additional']      = __( 'Ek Bilgiler', 'listingpro' );
+                    break;
+
+                case 'lp_faqs_section':
+                    if ( ! lp_onepage_on( $faqs_show ) || ! $has_faq || isset( $sections_markup['faq'] ) ) {
+                        break;
+                    }
+                    $faq_markup = lp_onepage_capture( 'templates/single-list/listing-details-style4/content/list-faq.php' );
+                    if ( empty( $faq_markup ) ) {
+                        break;
+                    }
+                    ob_start();
+                    ?>
+                    <section id="faq" class="lp-section lp-section-faq">
+                        <div class="container">
+                            <h2 class="lp-section-title"><?php echo esc_html__( 'SSS', 'listingpro' ); ?></h2>
+                            <?php echo $faq_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                        </div>
+                    </section>
+                    <?php
+                    $sections_markup['faq'] = ob_get_clean();
+                    $menu_items['faq']      = __( 'SSS', 'listingpro' );
+                    break;
+
+                case 'lp_announcements_section':
+                    if ( isset( $sections_markup['announcements'] ) ) {
+                        break;
+                    }
+                    $announcements_markup = lp_onepage_capture( 'templates/single-list/listing-details-style4/content/list-announcements.php' );
+                    if ( empty( $announcements_markup ) ) {
+                        break;
+                    }
+                    ob_start();
+                    ?>
+                    <section id="announcements" class="lp-section lp-section-announcements">
+                        <div class="container">
+                            <h2 class="lp-section-title"><?php echo esc_html__( 'Duyurular', 'listingpro' ); ?></h2>
+                            <?php echo $announcements_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                        </div>
+                    </section>
+                    <?php
+                    $sections_markup['announcements'] = ob_get_clean();
+                    $menu_items['announcements']      = __( 'Duyurular', 'listingpro' );
+                    break;
+
+                case 'lp_offers_section':
+                    if ( isset( $sections_markup['offers'] ) ) {
+                        break;
+                    }
+                    $offers_markup = lp_onepage_capture( 'templates/single-list/listing-details-style4/content/list-offer-deals-discount.php' );
+                    if ( empty( $offers_markup ) ) {
+                        break;
+                    }
+                    ob_start();
+                    ?>
+                    <section id="offers" class="lp-section lp-section-offers">
+                        <div class="container">
+                            <h2 class="lp-section-title"><?php echo esc_html__( 'Fırsatlar', 'listingpro' ); ?></h2>
+                            <?php echo $offers_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                        </div>
+                    </section>
+                    <?php
+                    $sections_markup['offers'] = ob_get_clean();
+                    $menu_items['offers']      = __( 'Fırsatlar', 'listingpro' );
+                    break;
+
+                case 'lp_menu_section':
+                    if ( isset( $sections_markup['menu'] ) ) {
+                        break;
+                    }
+                    $menu_markup = lp_onepage_capture( 'templates/single-list/listing-details-style4/content/list-menu.php' );
+                    if ( empty( $menu_markup ) ) {
+                        break;
+                    }
+                    ob_start();
+                    ?>
+                    <section id="menu" class="lp-section lp-section-menu">
+                        <div class="container">
+                            <h2 class="lp-section-title"><?php echo esc_html__( 'Menü', 'listingpro' ); ?></h2>
+                            <?php echo $menu_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                        </div>
+                    </section>
+                    <?php
+                    $sections_markup['menu'] = ob_get_clean();
+                    $menu_items['menu']      = __( 'Menü', 'listingpro' );
+                    break;
+
+                case 'lp_event_section':
+                    if ( isset( $sections_markup['events'] ) ) {
+                        break;
+                    }
+                    $event_displayin = get_user_meta( $post_author_id, 'event_display_area', true );
+                    if ( ! empty( $event_displayin ) && 'content' !== $event_displayin ) {
+                        break;
+                    }
+                    $GLOBALS['event_grid_call'] = 'content_area';
+                    $events_markup              = lp_onepage_capture( 'templates/single-list/event.php' );
+                    unset( $GLOBALS['event_grid_call'] );
+                    if ( empty( $events_markup ) ) {
+                        break;
+                    }
+                    ob_start();
+                    ?>
+                    <section id="events" class="lp-section lp-section-events">
+                        <div class="container">
+                            <h2 class="lp-section-title"><?php echo esc_html__( 'Etkinlikler', 'listingpro' ); ?></h2>
+                            <?php echo $events_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                        </div>
+                    </section>
+                    <?php
+                    $sections_markup['events'] = ob_get_clean();
+                    $menu_items['events']      = __( 'Etkinlikler', 'listingpro' );
+                    break;
+
+                case 'lp_booking_section':
+                    if ( isset( $sections_markup['booking'] ) ) {
+                        break;
+                    }
+                    $booking_markup = '';
+                    if ( class_exists( 'Listingpro_bookings' ) ) {
+                        $booking_template = WP_CONTENT_DIR . '/plugins/listingpro-bookings/templates/bookings.php';
+                        if ( file_exists( $booking_template ) ) {
+                            ob_start();
+                            include $booking_template;
+                            $booking_markup = trim( ob_get_clean() );
+                        }
+                    } elseif ( ! empty( $resurva_url ) ) {
+                        $booking_markup = '<iframe src="' . esc_url( $resurva_url ) . '" frameborder="0" style="width:100%;height:600px"></iframe>';
+                    } elseif ( ! empty( $timekit_booking ) ) {
+                        $booking_markup = $timekit_booking;
+                    }
+
+                    if ( empty( $booking_markup ) ) {
+                        break;
+                    }
+
+                    ob_start();
+                    ?>
+                    <section id="booking" class="lp-section lp-section-booking">
+                        <div class="container">
+                            <h2 class="lp-section-title"><?php echo esc_html__( 'Randevu', 'listingpro' ); ?></h2>
+                            <?php echo $booking_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                        </div>
+                    </section>
+                    <?php
+                    $sections_markup['booking'] = ob_get_clean();
+                    $menu_items['booking']      = __( 'Randevu', 'listingpro' );
+                    break;
+
+                case 'lp_quicks_section':
+                    if ( isset( $sections_markup['quick'] ) ) {
+                        break;
+                    }
+                    $quicks_markup = lp_onepage_capture( 'templates/single-list/listing-details-style4/sidebar/quicks.php' );
+                    if ( empty( $quicks_markup ) ) {
+                        break;
+                    }
+                    ob_start();
+                    ?>
+                    <section id="quick" class="lp-section lp-section-quick">
+                        <div class="container">
+                            <h2 class="lp-section-title"><?php echo esc_html__( 'Hızlı İşlemler', 'listingpro' ); ?></h2>
+                            <?php echo $quicks_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                        </div>
+                    </section>
+                    <?php
+                    $sections_markup['quick'] = ob_get_clean();
+                    $menu_items['quick']      = __( 'Hızlı İşlemler', 'listingpro' );
+                    break;
+
+                case 'lp_reviews_section':
+                    if ( isset( $sections_markup['reviews'] ) ) {
+                        break;
+                    }
+                    $reviews_markup = lp_onepage_capture( 'templates/single-list/listing-details-style6/content/reviews.php' );
+                    if ( empty( $reviews_markup ) ) {
+                        break;
+                    }
+                    ob_start();
+                    ?>
+                    <section id="reviews" class="lp-section lp-section-reviews">
+                        <div class="container">
+                            <h2 class="lp-section-title"><?php echo esc_html__( 'Yorumlar', 'listingpro' ); ?></h2>
+                            <?php echo $reviews_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                        </div>
+                    </section>
+                    <?php
+                    $sections_markup['reviews'] = ob_get_clean();
+                    $menu_items['reviews']      = __( 'Yorumlar', 'listingpro' );
+                    break;
+
+                case 'lp_reviewform_section':
+                    if ( isset( $sections_markup['reviewform'] ) ) {
+                        break;
+                    }
+                    $reviewform_markup = lp_onepage_capture( 'templates/single-list/listing-details-style4/content/list-review-form.php' );
+                    if ( empty( $reviewform_markup ) ) {
+                        break;
+                    }
+                    ob_start();
+                    ?>
+                    <section id="reviewform" class="lp-section lp-section-reviewform">
+                        <div class="container">
+                            <h2 class="lp-section-title"><?php echo esc_html__( 'Yorum Yaz', 'listingpro' ); ?></h2>
+                            <?php echo $reviewform_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                        </div>
+                    </section>
+                    <?php
+                    $sections_markup['reviewform'] = ob_get_clean();
+                    $menu_items['reviewform']      = __( 'Yorum Yaz', 'listingpro' );
+                    break;
+            }
         }
-        if ( $has_features_section ) {
-            $menu_items['features'] = __( 'Özellikler', 'listingpro' );
-        }
-        if ( $has_gallery ) {
-            $menu_items['gallery'] = __( 'Resim', 'listingpro' );
-        }
-        if ( $has_video ) {
-            $menu_items['video'] = __( 'Video', 'listingpro' );
-        }
-        if ( $has_reviews ) {
-            $menu_items['reviews'] = __( 'Yorumlar', 'listingpro' );
-        }
+
         if ( $has_map ) {
             $menu_items['map'] = __( 'Harita', 'listingpro' );
         }
@@ -322,217 +676,9 @@ if ( have_posts() ) {
         </div>
         <?php endif; ?>
 
-        <?php if ( $has_about ) : ?>
-            <section id="about" class="lp-section lp-section-about">
-                <div class="container">
-                    <h2 class="lp-section-title"><?php echo esc_html( $menu_items['about'] ); ?></h2>
-                    <?php echo apply_filters( 'the_content', $description ); ?>
-                </div>
-            </section>
-        <?php endif; ?>
-
-        <?php if ( $has_features_section ) : ?>
-            <section id="features" class="lp-section lp-section-features">
-                <div class="container">
-                    <h2 class="lp-section-title"><?php echo esc_html( $menu_items['features'] ); ?></h2>
-                    <?php
-                    if ( $has_features ) {
-                        get_template_part( 'templates/single-list/listing-details-style6/content/features' );
-                    } elseif ( $has_services ) {
-                        ?>
-                        <ul class="lp-services-list">
-                            <?php foreach ( $service_names as $service_name ) : ?>
-                                <li><?php echo esc_html( $service_name ); ?></li>
-                            <?php endforeach; ?>
-                        </ul>
-                        <?php
-                    }
-                    ?>
-                </div>
-            </section>
-        <?php endif; ?>
-
-        <?php if ( $has_gallery ) : ?>
-            <section id="gallery" class="lp-section lp-section-gallery">
-                <div class="container">
-                    <h2 class="lp-section-title"><?php echo esc_html( $menu_items['gallery'] ); ?></h2>
-                    <?php if ( ! empty( $gallery_ids ) ) : ?>
-                        <div class="lp-gallery-grid">
-                            <?php
-                            foreach ( $gallery_ids as $img_id ) {
-                                $full = wp_get_attachment_image_src( $img_id, 'full' );
-                                if ( empty( $full[0] ) ) {
-                                    continue;
-                                }
-                                $thumb = wp_get_attachment_image( $img_id, 'large', false, array( 'class' => 'lp-gallery-thumb' ) );
-                                if ( empty( $thumb ) ) {
-                                    $thumb = '<img class="lp-gallery-thumb" src="' . esc_url( $full[0] ) . '" alt="' . esc_attr( $lp_title ) . '" />';
-                                }
-                                echo '<a class="lp-gallery-item" href="' . esc_url( $full[0] ) . '" rel="prettyPhoto[gallery1]">' . $thumb . '</a>';
-                            }
-                            ?>
-                        </div>
-                    <?php endif; ?>
-                </div>
-            </section>
-        <?php endif; ?>
-
-        <?php if ( $has_video ) : ?>
-            <section id="video" class="lp-section lp-section-video">
-                <div class="container">
-                    <h2 class="lp-section-title"><?php echo esc_html( $menu_items['video'] ); ?></h2>
-                    <div class="lp-video-wrapper">
-                        <?php echo wp_kses( $video_html, array_merge( wp_kses_allowed_html( 'post' ), array( 'iframe' => array( 'src' => true, 'width' => true, 'height' => true, 'frameborder' => true, 'allowfullscreen' => true ) ) ) ); ?>
-                    </div>
-                </div>
-            </section>
-        <?php endif; ?>
-
-        <?php if ( $has_reviews ) : ?>
-            <section id="reviews" class="lp-section lp-section-reviews">
-                <div class="container">
-                    <h2 class="lp-section-title"><?php echo esc_html( $menu_items['reviews'] ); ?></h2>
-                    <?php get_template_part( 'templates/single-list/listing-details-style6/content/reviews' ); ?>
-                </div>
-            </section>
-        <?php endif; ?>
-
-        <?php
-        foreach ( $layout_general as $section_key ) {
-            if ( in_array( $section_key, array( 'lp_content_section', 'lp_services_section', 'lp_gallery_section', 'lp_video_section', 'lp_reviews_section', 'lp_features_section' ), true ) ) {
-                continue;
-            }
-            switch ( $section_key ) {
-                case 'lp_additional_section':
-                    if ( function_exists( 'listing_all_extra_fields' ) ) {
-                        $additional_html = listing_all_extra_fields( get_the_ID() );
-                        if ( ! empty( $additional_html ) ) {
-                            ?>
-                            <section id="additional" class="lp-section lp-section-additional">
-                                <div class="container">
-                                    <?php echo $additional_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-                                </div>
-                            </section>
-                            <?php
-                        }
-                    }
-                    break;
-                case 'lp_faqs_section':
-                    if ( lp_onepage_on( $faqs_show ) && $has_faq ) {
-                        ?>
-                        <section id="faq" class="lp-section lp-section-faq">
-                            <div class="container">
-                                <h2 class="lp-section-title"><?php echo esc_html__( 'SSS', 'listingpro' ); ?></h2>
-                                <?php get_template_part( 'templates/single-list/listing-details-style4/content/list-faq' ); ?>
-                            </div>
-                        </section>
-                        <?php
-                    }
-                    break;
-                case 'lp_announcements_section':
-                    if ( $has_announcements ) {
-                        ?>
-                        <section id="announcements" class="lp-section lp-section-announcements">
-                            <div class="container">
-                                <h2 class="lp-section-title"><?php echo esc_html__( 'Duyurular', 'listingpro' ); ?></h2>
-                                <?php get_template_part( 'templates/single-list/listing-details-style6/content/list-announcements' ); ?>
-                            </div>
-                        </section>
-                        <?php
-                    }
-                    break;
-                case 'lp_offers_section':
-                    $post_author_id      = get_post_field( 'post_author', get_the_ID() );
-                    $discount_displayin = get_user_meta( $post_author_id, 'discount_display_area', true );
-                    if ( 'content' === $discount_displayin || empty( $discount_displayin ) ) {
-                        ob_start();
-                        get_template_part( 'templates/single-list/listing-details-style6/content/list-offer-deals-discount' );
-                        $offers_html = trim( ob_get_clean() );
-                        if ( '' !== trim( wp_strip_all_tags( $offers_html ) ) ) {
-                            ?>
-                            <section id="offers" class="lp-section lp-section-offers">
-                                <div class="container">
-                                    <?php echo $offers_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-                                </div>
-                            </section>
-                            <?php
-                        }
-                    }
-                    break;
-                case 'lp_menu_section':
-                    if ( $menuOption ) {
-                        ?>
-                        <section id="menu" class="lp-section lp-section-menu">
-                            <div class="container">
-                                <h2 class="lp-section-title"><?php echo esc_html__( 'Menü', 'listingpro' ); ?></h2>
-                                <?php get_template_part( 'templates/single-list/listing-details-style6/content/list-menu' ); ?>
-                            </div>
-                        </section>
-                        <?php
-                    }
-                    break;
-                case 'lp_booking_section':
-                    if ( $timekit || ! empty( $resurva_url ) || class_exists( 'Listingpro_bookings' ) ) {
-                        ?>
-                        <section id="booking" class="lp-section lp-section-booking">
-                            <div class="container">
-                                <?php
-                                if ( class_exists( 'Listingpro_bookings' ) ) {
-                                    include WP_CONTENT_DIR . '/plugins/listingpro-bookings/templates/bookings.php';
-                                } elseif ( ! empty( $resurva_url ) ) {
-                                    echo '<iframe src="' . esc_url( $resurva_url ) . '" frameborder="0" style="width:100%;height:600px"></iframe>';
-                                }
-                                ?>
-                            </div>
-                        </section>
-                        <?php
-                    }
-                    break;
-                case 'lp_event_section':
-                    $post_author_id = get_post_field( 'post_author', get_the_ID() );
-                    $event_displayin = get_user_meta( $post_author_id, 'event_display_area', true );
-                    if ( 'content' === $event_displayin || empty( $event_displayin ) ) {
-                        $GLOBALS['event_grid_call'] = 'content_area';
-                        ob_start();
-                        get_template_part( 'templates/single-list/event' );
-                        $events_html = trim( ob_get_clean() );
-                        unset( $GLOBALS['event_grid_call'] );
-                        if ( '' !== trim( wp_strip_all_tags( $events_html ) ) ) {
-                            ?>
-                            <section id="events" class="lp-section lp-section-events">
-                                <div class="container">
-                                    <?php echo $events_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-                                </div>
-                            </section>
-                            <?php
-                        }
-                    }
-                    break;
-                case 'lp_quicks_section':
-                    ?>
-                    <section id="quicks" class="lp-section lp-section-quicks">
-                        <div class="container">
-                            <?php get_template_part( 'templates/single-list/listing-details-style6/sidebar/quicks' ); ?>
-                        </div>
-                    </section>
-                    <?php
-                    break;
-                case 'lp_reviewform_section':
-                    ob_start();
-                    get_template_part( 'templates/single-list/listing-details-style6/content/reviewform' );
-                    $review_form_html = trim( ob_get_clean() );
-                    if ( '' !== trim( wp_strip_all_tags( $review_form_html ) ) ) {
-                        ?>
-                        <section id="review-form" class="lp-section lp-section-reviewform">
-                            <div class="container">
-                                <?php echo $review_form_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-                            </div>
-                        </section>
-                        <?php
-                    }
-                    break;
-            }
-        }
+        <?php foreach ( $sections_markup as $section_html ) : ?>
+            <?php echo $section_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+        <?php endforeach; ?>
         ?>
 
         <?php if ( $has_map ) :

--- a/templates/listing-onepage.php
+++ b/templates/listing-onepage.php
@@ -210,7 +210,7 @@ if ( have_posts() ) {
         $announcements_raw = get_post_meta( get_the_ID(), 'lp_listing_announcements', true );
         $has_announcements = is_array( $announcements_raw ) && count( $announcements_raw ) > 0;
 
-        $has_map   = lp_onepage_on( $map_show ) && ! empty( $latitude ) && ! empty( $longitude );
+        $has_map   = ! empty( $latitude ) && ! empty( $longitude );
         $has_hours = is_array( $hours ) ? ! empty( array_filter( $hours ) ) : ! empty( $hours );
 
         $sections_markup = array();
@@ -768,31 +768,31 @@ if ( have_posts() ) {
             <div class="container">
                 <h2 class="lp-section-title"><?php echo esc_html( $menu_items['contact'] ); ?></h2>
                 <ul class="lp-contact-list">
-                    <?php if ( ! empty( $locations ) && lp_onepage_on( $location_show ) ) : ?>
+                    <?php if ( ! empty( $locations ) ) : ?>
                         <li class="lp-contact-location"><i class="fa fa-map-marker"></i><?php echo esc_html( $locations[0]->name ); ?></li>
                     <?php endif; ?>
                     <?php if ( ! empty( $categories ) ) : ?>
                         <li class="lp-contact-category"><i class="fa fa-folder-open"></i><?php echo esc_html( $categories[0]->name ); ?></li>
                     <?php endif; ?>
-                    <?php if ( lp_onepage_on( $location_show ) && ! empty( $address ) ) : ?>
+                    <?php if ( ! empty( $address ) ) : ?>
                         <li class="lp-contact-address"><i class="fa fa-location-arrow"></i><?php echo esc_html( $address ); ?><?php if ( ! empty( $latitude ) && ! empty( $longitude ) ) : ?> <a href="https://www.google.com/maps/search/?api=1&amp;query=<?php echo esc_attr( $latitude ); ?>,<?php echo esc_attr( $longitude ); ?>" target="_blank"><?php echo esc_html__( 'Yol Tarifi Al', 'listingpro' ); ?></a><?php endif; ?></li>
                     <?php endif; ?>
-                    <?php if ( lp_onepage_on( $contact_show ) && 'yes' === $email_switcher && ! empty( $email ) ) : ?>
+                    <?php if ( 'yes' === $email_switcher && ! empty( $email ) ) : ?>
                         <li class="lp-contact-email"><i class="fa fa-envelope"></i><a href="mailto:<?php echo esc_attr( $email ); ?>"><?php echo esc_html( $email ); ?></a></li>
                     <?php endif; ?>
                     <?php if ( ! empty( $phone ) ) : ?>
                         <li class="lp-contact-phone"><i class="fa fa-phone"></i><a href="tel:<?php echo esc_attr( $phone ); ?>"><?php echo esc_html( $phone ); ?></a></li>
                     <?php endif; ?>
-                    <?php if ( ! empty( $whatsapp ) ) : ?>
+                    <?php if ( ! empty( $whatsapp ) && ! empty( $wa_link ) ) : ?>
                         <li class="lp-contact-whatsapp"><i class="fa fa-whatsapp"></i><a href="<?php echo esc_url( $wa_link ); ?>" target="_blank"><?php echo esc_html( $whatsapp ); ?></a></li>
                     <?php endif; ?>
                     <?php if ( ! empty( $website ) ) : ?>
                         <li class="lp-contact-website"><i class="fa fa-globe"></i><a href="<?php echo esc_url( $website ); ?>" target="_blank"><?php echo esc_html( $website ); ?></a></li>
                     <?php endif; ?>
-                    <?php if ( lp_onepage_on( $price_show ) && ! empty( $price_html ) ) : ?>
+                    <?php if ( ! empty( $price_html ) ) : ?>
                         <li class="lp-contact-price"><?php echo wp_kses_post( $price_html ); ?></li>
                     <?php endif; ?>
-                    <?php if ( lp_onepage_on( $tags_show ) && ! empty( $tags_terms ) ) :
+                    <?php if ( ! empty( $tags_terms ) ) :
                         $tag_names = array();
                         foreach ( $tags_terms as $tag_term ) {
                             $tag_names[] = $tag_term->name;

--- a/templates/listing-onepage.php
+++ b/templates/listing-onepage.php
@@ -132,15 +132,22 @@ if ( have_posts() ) {
         $hours     = lp_onepage_meta( 'business_hours' );
         $faqs      = lp_onepage_meta_by_id( 'faqs', get_the_ID() );
         $has_faq   = false;
-        if ( is_array( $faqs ) ) {
-            if ( isset( $faqs['faq'] ) && is_array( $faqs['faq'] ) ) {
-                foreach ( $faqs['faq'] as $faq_item ) {
+        if ( is_array( $faqs ) && isset( $faqs['faq'] ) && is_array( $faqs['faq'] ) ) {
+            foreach ( $faqs['faq'] as $index => $faq_item ) {
+                if ( is_array( $faq_item ) ) {
                     $question = isset( $faq_item['lp_title'] ) ? trim( $faq_item['lp_title'] ) : '';
                     $answer   = isset( $faq_item['lp_desc'] ) ? trim( $faq_item['lp_desc'] ) : '';
-                    if ( '' !== $question || '' !== $answer ) {
-                        $has_faq = true;
-                        break;
+                } else {
+                    $question = trim( (string) $faq_item );
+                    $answer   = '';
+                    if ( isset( $faqs['faqans'][ $index ] ) ) {
+                        $answer = trim( (string) $faqs['faqans'][ $index ] );
                     }
+                }
+
+                if ( '' !== $question || '' !== $answer ) {
+                    $has_faq = true;
+                    break;
                 }
             }
         }
@@ -815,7 +822,7 @@ if ( have_posts() ) {
                 <?php
                 $additional_pos = isset( $listingpro_options['lp_detail_page_additional_styles'] ) ? $listingpro_options['lp_detail_page_additional_styles'] : '';
                 if ( function_exists( 'listing_all_extra_fields_v2_right' ) && 'right' === $additional_pos ) {
-                    listing_all_extra_fields_v2_right( get_the_ID() );
+                    echo listing_all_extra_fields_v2_right( get_the_ID() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
                 }
                 ?>
                 <?php get_template_part( 'templates/single-list/listing-details-style3/sidebar/lead-form' ); ?>

--- a/templates/listing-onepage.php
+++ b/templates/listing-onepage.php
@@ -53,9 +53,23 @@ if ( have_posts() ) {
             }
         }
 
-        $layout_general = isset( $listingpro_options['lp-detail-page-layout6-content']['general'] )
-            ? array_keys( $listingpro_options['lp-detail-page-layout6-content']['general'] )
-            : array( 'lp_content_section', 'lp_services_section', 'lp_gallery_section', 'lp_video_section', 'lp_faqs_section' );
+        $layout_general = array(
+            'lp_content_section',
+            'lp_services_section',
+            'lp_features_section',
+            'lp_gallery_section',
+            'lp_video_section',
+            'lp_announcements_section',
+            'lp_offers_section',
+            'lp_menu_section',
+            'lp_event_section',
+            'lp_booking_section',
+            'lp_quicks_section',
+            'lp_faqs_section',
+            'lp_additional_section',
+            'lp_reviews_section',
+            'lp_reviewform_section',
+        );
 
         $description = lp_onepage_meta( 'lp_listing_description' );
         if ( empty( $description ) ) {
@@ -195,8 +209,6 @@ if ( have_posts() ) {
         }
         $announcements_raw = get_post_meta( get_the_ID(), 'lp_listing_announcements', true );
         $has_announcements = is_array( $announcements_raw ) && count( $announcements_raw ) > 0;
-
-        $enabled_sections = array_flip( $layout_general );
 
         $has_map   = lp_onepage_on( $map_show ) && ! empty( $latitude ) && ! empty( $longitude );
         $has_hours = is_array( $hours ) ? ! empty( array_filter( $hours ) ) : ! empty( $hours );

--- a/templates/listing-onepage.php
+++ b/templates/listing-onepage.php
@@ -632,8 +632,6 @@ if ( have_posts() ) {
         .lp-social-list{list-style:none;margin:20px 0 0;padding:0;display:flex;gap:10px;justify-content:center;}
         .lp-social-list a{text-decoration:none;font-size:20px;}
         .lp-listing-tagline{margin-top:10px;font-size:18px;color:#555;}
-        .lp-home-meta{list-style:none;margin:10px 0 0;padding:0;display:flex;gap:15px;font-size:14px;color:#777;justify-content:center;}
-        .lp-home-meta li{display:flex;align-items:center;gap:5px;}
         .lp-whatsapp-float{position:fixed;right:20px;bottom:20px;width:50px;height:50px;border-radius:50%;background:#25d366;color:#fff;display:flex;align-items:center;justify-content:center;font-size:24px;z-index:1000;}
         .lp-hero-banner{position:relative;min-height:360px;background-size:cover;background-position:center center;border-radius:12px;margin:20px auto;max-width:1170px;overflow:hidden;}
         .lp-hero-banner .lp-header-overlay{position:absolute;top:0;left:0;width:100%;height:100%;background:rgba(15,23,42,0.25);}
@@ -666,24 +664,6 @@ if ( have_posts() ) {
                 <div class="lp-header-overlay"></div>
             </div>
         </section>
-        <?php if ( ! empty( $locations ) || ! empty( $categories ) || ! empty( $price_html ) ) : ?>
-        <div class="lp-home-meta-wrap">
-            <div class="container">
-                <ul class="lp-home-meta">
-                    <?php if ( ! empty( $locations ) ) : ?>
-                        <li><i class="fa fa-map-marker"></i><?php echo esc_html( $locations[0]->name ); ?></li>
-                    <?php endif; ?>
-                    <?php if ( ! empty( $categories ) ) : ?>
-                        <li><i class="fa fa-folder-open"></i><?php echo esc_html( $categories[0]->name ); ?></li>
-                    <?php endif; ?>
-                    <?php if ( ! empty( $price_html ) ) : ?>
-                        <li><?php echo wp_kses_post( $price_html ); ?></li>
-                    <?php endif; ?>
-                </ul>
-            </div>
-        </div>
-        <?php endif; ?>
-
         <?php foreach ( $sections_markup as $section_html ) : ?>
             <?php echo $section_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
         <?php endforeach; ?>

--- a/templates/listing-onepage.php
+++ b/templates/listing-onepage.php
@@ -131,7 +131,6 @@ if ( have_posts() ) {
                 'lp_menu_section',
                 'lp_event_section',
                 'lp_booking_section',
-                'lp_quicks_section',
                 'lp_faqs_section',
                 'lp_additional_section',
                 'lp_reviews_section',
@@ -573,33 +572,6 @@ if ( have_posts() ) {
                     <?php
                     $sections_markup['booking'] = ob_get_clean();
                     $menu_items['booking']      = __( 'Randevu', 'listingpro' );
-                    break;
-
-                case 'lp_quicks_section':
-                    if ( isset( $sections_markup['quick'] ) ) {
-                        break;
-                    }
-                    $quicks_markup = lp_onepage_capture(
-                        'templates/single-list/listing-details-style4/sidebar/quicks.php',
-                        array(
-                            'currentUserId' => $currentUserId,
-                            'showReport'    => $showReport,
-                        )
-                    );
-                    if ( empty( $quicks_markup ) ) {
-                        break;
-                    }
-                    ob_start();
-                    ?>
-                    <section id="quick" class="lp-section lp-section-quick">
-                        <div class="container">
-                            <h2 class="lp-section-title"><?php echo esc_html__( 'Hızlı İşlemler', 'listingpro' ); ?></h2>
-                            <?php echo $quicks_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-                        </div>
-                    </section>
-                    <?php
-                    $sections_markup['quick'] = ob_get_clean();
-                    $menu_items['quick']      = __( 'Hızlı İşlemler', 'listingpro' );
                     break;
 
                 case 'lp_reviews_section':


### PR DESCRIPTION
## Summary
- map one-page listing template to selectable style 6 while keeping existing style 5
- load one-page layout when style 6 is chosen on the single listing page
- render gallery images individually in one-page template to avoid fatal error
- style one-page template header and sections for professional layout
- honor style 6 content layout options to toggle About, Services, Gallery, and Video blocks
- move style 6 layout controls above mobile layout in theme options
- add map and hours data from sidebar into one-page menu and sections
- show email, WhatsApp, and social links in one-page contact section
- add gallery and video sections to layout 6 options and menu labels
- guard listing meta lookups with fallbacks to prevent fatal error when helper functions are missing
- fix unclosed braces in the one-page template's foreach block to prevent parse errors
- populate one-page sections with listing content, services taxonomy, gallery attachments, and tagline fallback
- display listing location, category, and price under the title in one-page layout
- integrate style 4 hero header and gallery into the one-page template for richer top section
- define title, claim, tagline, and rating variables before including style 4 title bar to stop runtime warnings
- cast video output to string to avoid deprecated preg_replace warning

## Testing
- `php -l templates/listing-onepage.php`
- `php -l single-listing.php`


------
https://chatgpt.com/codex/tasks/task_e_68bebfb2d4648323931113930ca41bfd