### PR TITLE
Hide default header elements in one-page layout

### DIFF
--- a/assets/css/listing-onepage.css
+++ b/assets/css/listing-onepage.css
@@ -1,0 +1,62 @@
+/* Listing one-page style */
+.lp-onepage-header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 999;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 15px 30px;
+    background: #fff;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+.lp-onepage-logo img {
+    max-height: 60px;
+    width: auto;
+}
+.lp-onepage-nav ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    gap: 20px;
+}
+.lp-onepage-nav a {
+    color: #333;
+    text-decoration: none;
+    font-weight: 600;
+}
+.lp-onepage-nav a:hover {
+    color: #ff4e00;
+}
+.lp-section {
+    padding: 100px 20px 60px;
+}
+.lp-section:nth-of-type(even) {
+    background: #f9f9f9;
+}
+.lp-section-home {
+    text-align: center;
+    padding-top: 140px;
+}
+.lp-onepage-title {
+    font-size: 2.5rem;
+    margin: 0;
+}
+.lp-contact-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    text-align: center;
+}
+.lp-contact-list li {
+    margin-bottom: 10px;
+}
+
+#page.lp_detail_page_styles7 .lp-listing-top-title-header,
+#page.lp_detail_page_styles7 .lp-listing-slider,
+#page.lp_detail_page_styles7 .lp-see-all {
+    display: none;
+}

--- a/assets/css/listing-onepage.css
+++ b/assets/css/listing-onepage.css
@@ -1,62 +1,418 @@
 /* Listing one-page style */
-.lp-onepage-header {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    z-index: 999;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 15px 30px;
-    background: #fff;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-}
-.lp-onepage-logo img {
-    max-height: 60px;
-    width: auto;
-}
-.lp-onepage-nav ul {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: flex;
-    gap: 20px;
-}
-.lp-onepage-nav a {
-    color: #333;
-    text-decoration: none;
-    font-weight: 600;
-}
-.lp-onepage-nav a:hover {
-    color: #ff4e00;
-}
-.lp-section {
-    padding: 100px 20px 60px;
-}
-.lp-section:nth-of-type(even) {
-    background: #f9f9f9;
-}
-.lp-section-home {
-    text-align: center;
-    padding-top: 140px;
-}
-.lp-onepage-title {
-    font-size: 2.5rem;
-    margin: 0;
-}
-.lp-contact-list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    text-align: center;
-}
-.lp-contact-list li {
-    margin-bottom: 10px;
+
+#page.lp_detail_page_styles7 {
+    background: #f5f7fb;
 }
 
 #page.lp_detail_page_styles7 .lp-listing-top-title-header,
 #page.lp_detail_page_styles7 .lp-listing-slider,
 #page.lp_detail_page_styles7 .lp-see-all {
+    display: none !important;
+}
+
+body.lp-onepage-active {
+    background: #f5f7fb;
+}
+
+.lp-onepage-header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 1000;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 18px 40px;
+    background: #0e1a2b;
+    box-shadow: 0 8px 24px rgba(14, 26, 43, 0.2);
+}
+
+.lp-onepage-brand img {
+    max-height: 64px;
+    width: auto;
+    display: block;
+}
+
+.lp-onepage-brand-text {
+    color: #fff;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.lp-onepage-nav {
+    transition: transform 0.3s ease;
+}
+
+.lp-onepage-nav ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    gap: 28px;
+    align-items: center;
+}
+
+.lp-onepage-nav a {
+    color: rgba(255, 255, 255, 0.75);
+    font-weight: 600;
+    font-size: 14px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    text-decoration: none;
+    position: relative;
+    padding-bottom: 6px;
+}
+
+.lp-onepage-nav a::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    width: 100%;
+    height: 2px;
+    background: linear-gradient(135deg, #06beb6, #48b1bf);
+    opacity: 0;
+    transform: scaleX(0.6);
+    transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.lp-onepage-nav a:hover,
+.lp-onepage-nav a.is-active {
+    color: #fff;
+}
+
+.lp-onepage-nav a:hover::after,
+.lp-onepage-nav a.is-active::after {
+    opacity: 1;
+    transform: scaleX(1);
+}
+
+.lp-onepage-nav-toggle {
     display: none;
+    flex-direction: column;
+    gap: 5px;
+    background: transparent;
+    border: 0;
+    padding: 6px;
+    cursor: pointer;
+}
+
+.lp-onepage-nav-toggle span {
+    width: 28px;
+    height: 3px;
+    background: #fff;
+    display: block;
+    border-radius: 2px;
+}
+
+.lp-section {
+    position: relative;
+    padding: 120px 20px 80px;
+    scroll-margin-top: 120px;
+}
+
+.lp-onepage-container {
+    max-width: 1140px;
+    margin: 0 auto;
+}
+
+.lp-onepage-hero {
+    min-height: 540px;
+    display: flex;
+    align-items: flex-end;
+    padding-bottom: 80px;
+    color: #fff;
+    background-size: cover;
+    background-position: center;
+}
+
+.lp-onepage-hero__overlay {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(180deg, rgba(14, 26, 43, 0.2) 0%, rgba(14, 26, 43, 0.85) 100%);
+}
+
+.lp-onepage-hero .lp-onepage-container {
+    position: relative;
+    z-index: 1;
+}
+
+.lp-onepage-hero__categories {
+    margin-bottom: 16px;
+    font-size: 14px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.7);
+}
+
+.lp-onepage-title {
+    font-size: 48px;
+    font-weight: 700;
+    margin: 0;
+    display: flex;
+    align-items: center;
+    gap: 16px;
+}
+
+.lp-onepage-claimed {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: rgba(6, 190, 182, 0.2);
+    color: #06beb6;
+    font-size: 13px;
+    font-weight: 600;
+    padding: 6px 14px;
+    border-radius: 999px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.lp-onepage-tagline {
+    margin: 18px 0 0;
+    font-size: 18px;
+    max-width: 720px;
+    color: rgba(255, 255, 255, 0.85);
+}
+
+.lp-onepage-hero__meta {
+    margin-top: 28px;
+    display: flex;
+    align-items: center;
+    gap: 24px;
+}
+
+.lp-onepage-rating {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 16px;
+}
+
+.lp-onepage-rating__count {
+    color: rgba(255, 255, 255, 0.75);
+    font-weight: 600;
+}
+
+.lp-onepage-info-bar {
+    background: #fff;
+    box-shadow: 0 20px 40px rgba(14, 26, 43, 0.08);
+}
+
+.lp-onepage-info-bar ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px 32px;
+    align-items: center;
+    justify-content: center;
+    padding: 22px 30px;
+}
+
+.lp-onepage-info-bar li {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    font-weight: 600;
+    color: #0e1a2b;
+}
+
+.lp-onepage-info-bar a {
+    color: inherit;
+    text-decoration: none;
+}
+
+.lp-onepage-section {
+    background: #fff;
+    border-radius: 24px;
+    margin: 40px auto;
+    padding: 80px 60px;
+    box-shadow: 0 20px 50px rgba(14, 26, 43, 0.06);
+}
+
+.lp-onepage-section__header h2 {
+    margin: 0 0 24px;
+    font-size: 32px;
+    font-weight: 700;
+    color: #0e1a2b;
+}
+
+.lp-onepage-section__content {
+    font-size: 17px;
+    color: #3b4658;
+    line-height: 1.8;
+}
+
+.lp-onepage-features {
+    list-style: none;
+    padding: 0;
+    margin: 32px 0 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 14px 20px;
+}
+
+.lp-onepage-features li {
+    background: rgba(6, 190, 182, 0.1);
+    color: #049b96;
+    padding: 10px 18px;
+    border-radius: 999px;
+    font-weight: 600;
+    font-size: 14px;
+}
+
+.lp-onepage-gallery {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: 20px;
+}
+
+.lp-onepage-gallery a {
+    display: block;
+    border-radius: 18px;
+    overflow: hidden;
+    box-shadow: 0 12px 30px rgba(14, 26, 43, 0.12);
+}
+
+.lp-onepage-gallery img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+    transition: transform 0.4s ease;
+}
+
+.lp-onepage-gallery a:hover img {
+    transform: scale(1.05);
+}
+
+.lp-onepage-video iframe,
+.lp-onepage-video video {
+    width: 100%;
+    min-height: 420px;
+    border-radius: 20px;
+    border: 0;
+    box-shadow: 0 20px 45px rgba(14, 26, 43, 0.2);
+}
+
+.lp-onepage-faq details {
+    background: #f5f7fb;
+    border-radius: 18px;
+    padding: 18px 24px;
+    margin-bottom: 16px;
+    border: 1px solid rgba(14, 26, 43, 0.06);
+}
+
+.lp-onepage-faq summary {
+    cursor: pointer;
+    font-weight: 600;
+    color: #0e1a2b;
+}
+
+.lp-onepage-faq__answer {
+    margin-top: 12px;
+    color: #3b4658;
+}
+
+.lp-onepage-map iframe {
+    width: 100%;
+    min-height: 420px;
+    border: 0;
+    border-radius: 20px;
+    box-shadow: 0 18px 36px rgba(14, 26, 43, 0.15);
+}
+
+.lp-onepage-contact ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 18px;
+    color: #3b4658;
+}
+
+.lp-onepage-contact a {
+    color: inherit;
+    text-decoration: none;
+}
+
+@media (max-width: 1024px) {
+    .lp-onepage-header {
+        padding: 16px 24px;
+    }
+
+    .lp-onepage-nav {
+        position: absolute;
+        top: 100%;
+        right: 0;
+        background: #0e1a2b;
+        width: 220px;
+        transform: translateY(-10px);
+        opacity: 0;
+        pointer-events: none;
+        box-shadow: 0 20px 40px rgba(14, 26, 43, 0.3);
+    }
+
+    .lp-onepage-nav ul {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0;
+    }
+
+    .lp-onepage-nav li {
+        width: 100%;
+    }
+
+    .lp-onepage-nav a {
+        display: block;
+        width: 100%;
+        padding: 14px 22px;
+    }
+
+    .lp-onepage-nav.is-open {
+        transform: translateY(0);
+        opacity: 1;
+        pointer-events: auto;
+    }
+
+    .lp-onepage-nav-toggle {
+        display: flex;
+    }
+
+    .lp-onepage-section {
+        padding: 60px 34px;
+    }
+}
+
+@media (max-width: 767px) {
+    .lp-onepage-title {
+        font-size: 34px;
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .lp-onepage-hero {
+        padding: 120px 20px 60px;
+        min-height: 420px;
+    }
+
+    .lp-onepage-info-bar ul {
+        justify-content: flex-start;
+    }
+
+    .lp-onepage-section {
+        padding: 50px 24px;
+        border-radius: 20px;
+    }
+
+    .lp-onepage-video iframe,
+    .lp-onepage-video video,
+    .lp-onepage-map iframe {
+        min-height: 280px;
+    }
 }

--- a/functions.php
+++ b/functions.php
@@ -239,13 +239,18 @@ if (!function_exists('listingpro_style')) {
 		wp_enqueue_style('bootstrapslider', THEME_DIR . '/assets/lib/bootstrap/css/bootstrap-slider.css');
 		//}
 
-		wp_enqueue_style('mourisjs', THEME_DIR . '/assets/css/morris.css');
+                wp_enqueue_style('mourisjs', THEME_DIR . '/assets/css/morris.css');
 
-		wp_enqueue_style('listingpro', STYLESHEET_DIR . '/style.css');
-		$mobile_view = lp_theme_option('single_listing_mobile_view');
-		if ($mobile_view == 'app_view2' && wp_is_mobile()) {
-			wp_enqueue_style('app-view2-styles', THEME_DIR . '/assets/css/app-view2.css');
-		}
+                wp_enqueue_style('listingpro', STYLESHEET_DIR . '/style.css');
+
+                $lp_detail_page_styles = isset($listingpro_options['lp_detail_page_styles']) ? $listingpro_options['lp_detail_page_styles'] : '';
+                if (is_singular('listing') && $lp_detail_page_styles == 'lp_detail_page_styles7') {
+                        wp_enqueue_style('listing-onepage', THEME_DIR . '/assets/css/listing-onepage.css');
+                }
+                $mobile_view = lp_theme_option('single_listing_mobile_view');
+                if ($mobile_view == 'app_view2' && wp_is_mobile()) {
+                        wp_enqueue_style('app-view2-styles', THEME_DIR . '/assets/css/app-view2.css');
+                }
 		if (is_rtl()) {
 			wp_enqueue_style('lp-rtl', THEME_DIR . '/assets/css/rtl.css');
 		}

--- a/include/options-config.php
+++ b/include/options-config.php
@@ -2181,13 +2181,14 @@ Redux::setSection($opt_name, array(
             'id' => 'lp_detail_page_styles',
             'type' => 'select',
             'title' => __('Select listing detail page Style', 'listingpro'),
-            'desc' => __('Choose from 1 of 4 styles.', 'listingpro'),
+            'desc' => __('Choose from available styles.', 'listingpro'),
             'options' => array(
                 'lp_detail_page_styles1' => 'Listing Detail Page Style 1',
                 'lp_detail_page_styles2' => 'Listing Detail Page Style 2',
                 'lp_detail_page_styles3' => 'Listing Detail Page Style 3',
                 'lp_detail_page_styles4' => 'Listing Detail Page Style 4',
-				'lp_detail_page_styles6' => 'Listing Detail Page Style 5' //classic new style
+                                'lp_detail_page_styles6' => 'Listing Detail Page Style 5', //classic new style
+                'lp_detail_page_styles7' => 'Listing One Page Style',
                 /* 'lp_detail_page_styles5' => 'Listing Detail Page Style 5', */
             ),
             'default' => 'lp_detail_page_styles1',

--- a/templates/listing-onepage.php
+++ b/templates/listing-onepage.php
@@ -3,87 +3,411 @@
 if ( have_posts() ) {
     while ( have_posts() ) {
         the_post();
-        $menu_items = array('home' => __('Anasayfa', 'listingpro'));
-        if ( listingpro_get_metabox('lp_listing_description') ) {
-            $menu_items['about'] = __('Hakkımızda', 'listingpro');
+        setPostViews( get_the_ID() );
+
+        global $listingpro_options, $post;
+
+        $plan_id = listing_get_metabox_by_ID( 'Plan_id', get_the_ID() );
+        if ( empty( $plan_id ) ) {
+            $plan_id = 'none';
         }
-        $services = listingpro_get_metabox('lp_services');
-        if ( ! empty( $services ) ) {
-            $menu_items['services'] = __('Hizmetler', 'listingpro');
+
+        $contact_show  = get_post_meta( $plan_id, 'contact_show', true );
+        $map_show      = get_post_meta( $plan_id, 'map_show', true );
+        $gallery_show  = get_post_meta( $plan_id, 'gallery_show', true );
+        $video_show    = get_post_meta( $plan_id, 'video_show', true );
+        $tagline_show  = get_post_meta( $plan_id, 'listingproc_tagline', true );
+        $location_show = get_post_meta( $plan_id, 'listingproc_location', true );
+        $website_show  = get_post_meta( $plan_id, 'listingproc_website', true );
+        $social_show   = get_post_meta( $plan_id, 'listingproc_social', true );
+        $faqs_show     = get_post_meta( $plan_id, 'listingproc_faq', true );
+
+        if ( 'none' === $plan_id ) {
+            $contact_show  = 'true';
+            $map_show      = 'true';
+            $gallery_show  = 'true';
+            $video_show    = 'true';
+            $tagline_show  = 'true';
+            $location_show = 'true';
+            $website_show  = 'true';
+            $social_show   = 'true';
+            $faqs_show     = 'true';
         }
-        $gallery = listingpro_get_metabox('lp_gallery');
-        if ( ! empty( $gallery ) ) {
-            $menu_items['gallery'] = __('Galeri', 'listingpro');
+
+        $tagline        = listing_get_metabox( 'tagline_text' );
+        $claimed        = listing_get_metabox( 'claimed_section' );
+        $featured_image = get_the_post_thumbnail_url( get_the_ID(), 'full' );
+        $logo_id        = listing_get_metabox_by_ID( 'business_logo', get_the_ID() );
+        $logo_url       = ! empty( $logo_id ) ? $logo_id : '';
+
+        if ( empty( $logo_url ) ) {
+            $default_logo = isset( $listingpro_options['business_logo_default']['url'] ) ? $listingpro_options['business_logo_default']['url'] : '';
+            $logo_url     = $default_logo;
         }
-        $video = listingpro_get_metabox('lp_video_embed');
-        if ( ! empty( $video ) ) {
-            $menu_items['video'] = __('Video', 'listingpro');
+
+        $rating_count = listingpro_ratings_numbers( get_the_ID() );
+        $rating_html  = lp_cal_listing_rate( get_the_ID() );
+
+        $categories = get_the_term_list( get_the_ID(), 'listing-category', '', ', ', '' );
+
+        $address      = listingpro_get_metabox( 'gAddress' );
+        $phone        = listingpro_get_metabox( 'phone' );
+        $email        = listingpro_get_metabox( 'email' );
+        $website      = listingpro_get_metabox( 'website' );
+        $whatsapp     = listingpro_get_metabox( 'whatsapp' );
+        $latitude     = listingpro_get_metabox( 'latitude' );
+        $longitude    = listingpro_get_metabox( 'longitude' );
+        $email_toggle = lp_theme_option( 'listingpro_email_display_switch' );
+
+        $services_meta = listingpro_get_metabox( 'lp_services' );
+        $video_meta    = listingpro_get_metabox( 'lp_video_embed' );
+        $faqs_meta     = listing_get_metabox_by_ID( 'faqs', get_the_ID() );
+
+        $gallery_ids = get_post_meta( get_the_ID(), 'gallery_image_ids', true );
+        if ( ! is_array( $gallery_ids ) ) {
+            $gallery_ids = array();
         }
-        $menu_items['contact'] = __('İletişim', 'listingpro');
+
+        $content_raw  = get_post_field( 'post_content', get_the_ID() );
+        $has_overview = ! empty( trim( wp_strip_all_tags( $content_raw ) ) );
+        if ( ! $has_overview ) {
+            $has_overview = ! empty( $tagline ) || ! empty( $categories );
+        }
+
+        $has_services = ! empty( $services_meta );
+        $has_gallery  = 'true' === $gallery_show && ! empty( $gallery_ids );
+        $has_video    = 'true' === $video_show && ! empty( $video_meta );
+
+        $has_faqs = false;
+        if ( 'true' === $faqs_show && ! empty( $faqs_meta ) && isset( $faqs_meta['faq'] ) ) {
+            $faq_questions = array_filter( $faqs_meta['faq'] );
+            $has_faqs      = ! empty( $faq_questions );
+        }
+
+        ob_start();
+        get_template_part( 'templates/single-list/listing-details-style1/content/reviews' );
+        $reviews_markup = trim( ob_get_clean() );
+        $has_reviews    = ! empty( $reviews_markup );
+
+        $menu_items = array( 'hero' => __( 'Anasayfa', 'listingpro' ) );
+        if ( $has_overview ) {
+            $menu_items['overview'] = __( 'İlan Bilgileri', 'listingpro' );
+        }
+        if ( $has_services ) {
+            $menu_items['services'] = __( 'Hizmetler', 'listingpro' );
+        }
+        if ( $has_gallery ) {
+            $menu_items['gallery'] = __( 'Galeri', 'listingpro' );
+        }
+        if ( $has_video ) {
+            $menu_items['video'] = __( 'Video', 'listingpro' );
+        }
+        if ( $has_faqs ) {
+            $menu_items['faq'] = __( 'S.S.S.', 'listingpro' );
+        }
+        if ( $has_reviews ) {
+            $menu_items['reviews'] = __( 'Yorumlar', 'listingpro' );
+        }
+        if ( ! empty( $latitude ) && ! empty( $longitude ) && 'true' === $map_show ) {
+            $menu_items['location'] = __( 'Konum', 'listingpro' );
+        }
+        $menu_items['contact'] = __( 'İletişim', 'listingpro' );
         ?>
+
         <header class="lp-onepage-header">
-            <div class="lp-onepage-logo"><?php the_post_thumbnail('medium'); ?></div>
-            <nav class="lp-onepage-nav">
+            <div class="lp-onepage-brand">
+                <?php if ( ! empty( $logo_url ) ) : ?>
+                    <img src="<?php echo esc_url( $logo_url ); ?>" alt="<?php echo esc_attr( get_the_title() ); ?>">
+                <?php else : ?>
+                    <span class="lp-onepage-brand-text"><?php bloginfo( 'name' ); ?></span>
+                <?php endif; ?>
+            </div>
+            <button class="lp-onepage-nav-toggle" aria-expanded="false" aria-controls="lp-onepage-menu">
+                <span></span>
+                <span></span>
+                <span></span>
+            </button>
+            <nav class="lp-onepage-nav" id="lp-onepage-menu">
                 <ul>
                     <?php foreach ( $menu_items as $slug => $label ) : ?>
-                        <li><a href="#<?php echo esc_attr( $slug ); ?>"><?php echo esc_html( $label ); ?></a></li>
+                        <li><a href="#<?php echo esc_attr( $slug ); ?>" data-target="<?php echo esc_attr( $slug ); ?>"><?php echo esc_html( $label ); ?></a></li>
                     <?php endforeach; ?>
                 </ul>
             </nav>
         </header>
 
-        <section id="home" class="lp-section lp-section-home">
-            <?php the_title('<h1 class="lp-onepage-title">', '</h1>'); ?>
-        </section>
-
-        <?php if ( isset( $menu_items['about'] ) ) : ?>
-        <section id="about" class="lp-section lp-section-about">
-            <?php echo apply_filters( 'the_content', listingpro_get_metabox( 'lp_listing_description' ) ); ?>
-        </section>
-        <?php endif; ?>
-
-        <?php if ( isset( $menu_items['services'] ) ) : ?>
-        <section id="services" class="lp-section lp-section-services">
-            <?php echo do_shortcode( $services ); ?>
-        </section>
-        <?php endif; ?>
-
-        <?php if ( isset( $menu_items['gallery'] ) ) : ?>
-        <section id="gallery" class="lp-section lp-section-gallery">
-            <?php echo listingpro_get_metabox( 'lp_gallery' ); ?>
-        </section>
-        <?php endif; ?>
-
-        <?php if ( isset( $menu_items['video'] ) ) : ?>
-        <section id="video" class="lp-section lp-section-video">
-            <?php echo listingpro_get_metabox( 'lp_video_embed' ); ?>
-        </section>
-        <?php endif; ?>
-
-        <section id="contact" class="lp-section lp-section-contact">
-            <ul class="lp-contact-list">
-                <?php $address = listingpro_get_metabox( 'gAddress' ); if ( $address ) : ?>
-                    <li class="lp-contact-address"><?php echo esc_html( $address ); ?></li>
+        <section id="hero" class="lp-section lp-onepage-hero" style="<?php echo $featured_image ? 'background-image: url(' . esc_url( $featured_image ) . ');' : ''; ?>">
+            <div class="lp-onepage-hero__overlay"></div>
+            <div class="lp-onepage-container">
+                <?php if ( $categories ) : ?>
+                    <div class="lp-onepage-hero__categories"><?php echo wp_kses_post( $categories ); ?></div>
                 <?php endif; ?>
-                <?php $phone = listingpro_get_metabox( 'phone' ); if ( $phone ) : ?>
-                    <li class="lp-contact-phone"><?php echo esc_html( $phone ); ?></li>
+                <h1 class="lp-onepage-title"><?php the_title(); ?><?php if ( 'claimed' === $claimed ) : ?><span class="lp-onepage-claimed"><?php esc_html_e( 'Onaylı', 'listingpro' ); ?></span><?php endif; ?></h1>
+                <?php if ( ! empty( $tagline ) && 'true' === $tagline_show ) : ?>
+                    <p class="lp-onepage-tagline"><?php echo esc_html( $tagline ); ?></p>
                 <?php endif; ?>
-                <?php $website = listingpro_get_metabox( 'website' ); if ( $website ) : ?>
-                    <li class="lp-contact-website"><a href="<?php echo esc_url( $website ); ?>" target="_blank"><?php echo esc_html( $website ); ?></a></li>
+                <div class="lp-onepage-hero__meta">
+                    <div class="lp-onepage-rating">
+                        <?php echo wp_kses_post( $rating_html ); ?>
+                        <?php if ( $rating_count ) : ?>
+                            <span class="lp-onepage-rating__count"><?php echo esc_html( $rating_count ); ?> <?php esc_html_e( 'oy', 'listingpro' ); ?></span>
+                        <?php endif; ?>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <?php if ( $contact_show === 'true' && ( $address || ( $email && 'yes' === $email_toggle ) || $phone || $website || $whatsapp ) ) : ?>
+            <div class="lp-onepage-info-bar">
+                <div class="lp-onepage-container">
+                    <ul>
+                        <?php if ( $address && 'true' === $location_show ) : ?>
+                            <li><i class="fa-solid fa-location-dot" aria-hidden="true"></i><?php echo esc_html( $address ); ?></li>
+                        <?php endif; ?>
+                        <?php if ( $email && 'yes' === $email_toggle ) : ?>
+                            <li><i class="fa fa-envelope" aria-hidden="true"></i><a href="mailto:<?php echo esc_attr( $email ); ?>"><?php echo esc_html( $email ); ?></a></li>
+                        <?php endif; ?>
+                        <?php if ( $phone ) : ?>
+                            <li><i class="fa-solid fa-phone" aria-hidden="true"></i><a href="tel:<?php echo esc_attr( $phone ); ?>"><?php echo esc_html( $phone ); ?></a></li>
+                        <?php endif; ?>
+                        <?php if ( $website && 'true' === $website_show ) : ?>
+                            <li><i class="fa-solid fa-globe" aria-hidden="true"></i><a href="<?php echo esc_url( $website ); ?>" target="_blank" rel="nofollow noopener"><?php echo esc_html( $website ); ?></a></li>
+                        <?php endif; ?>
+                        <?php if ( $whatsapp ) : ?>
+                            <li><i class="fa fa-whatsapp" aria-hidden="true"></i><a href="https://api.whatsapp.com/send?phone=<?php echo rawurlencode( $whatsapp ); ?>" target="_blank" rel="nofollow noopener"><?php esc_html_e( 'WhatsApp', 'listingpro' ); ?></a></li>
+                        <?php endif; ?>
+                    </ul>
+                </div>
+            </div>
+        <?php endif; ?>
+
+        <?php if ( $has_overview ) : ?>
+        <section id="overview" class="lp-section lp-onepage-section">
+            <div class="lp-onepage-container">
+                <header class="lp-onepage-section__header">
+                    <h2><?php esc_html_e( 'İlan Bilgileri', 'listingpro' ); ?></h2>
+                </header>
+                <div class="lp-onepage-section__content">
+                    <?php the_content(); ?>
+                </div>
+                <?php
+                $features = get_the_terms( get_the_ID(), 'features' );
+                if ( ! empty( $features ) && ! is_wp_error( $features ) ) :
+                ?>
+                    <ul class="lp-onepage-features">
+                        <?php foreach ( $features as $feature ) : ?>
+                            <li><?php echo esc_html( $feature->name ); ?></li>
+                        <?php endforeach; ?>
+                    </ul>
                 <?php endif; ?>
-            </ul>
+            </div>
+        </section>
+        <?php endif; ?>
+
+        <?php if ( $has_services ) : ?>
+        <section id="services" class="lp-section lp-onepage-section">
+            <div class="lp-onepage-container">
+                <header class="lp-onepage-section__header">
+                    <h2><?php esc_html_e( 'Hizmetler', 'listingpro' ); ?></h2>
+                </header>
+                <div class="lp-onepage-section__content">
+                    <?php echo do_shortcode( $services_meta ); ?>
+                </div>
+            </div>
+        </section>
+        <?php endif; ?>
+
+        <?php if ( $has_gallery ) : ?>
+        <section id="gallery" class="lp-section lp-onepage-section">
+            <div class="lp-onepage-container">
+                <header class="lp-onepage-section__header">
+                    <h2><?php esc_html_e( 'Galeri', 'listingpro' ); ?></h2>
+                </header>
+                <div class="lp-onepage-gallery">
+                    <?php foreach ( $gallery_ids as $image_id ) :
+                        $image = wp_get_attachment_image_src( $image_id, 'large' );
+                        if ( empty( $image ) ) {
+                            continue;
+                        }
+                        $full = wp_get_attachment_image_src( $image_id, 'full' );
+                    ?>
+                        <a href="<?php echo esc_url( $full[0] ); ?>" rel="prettyPhoto[gallery1]">
+                            <img src="<?php echo esc_url( $image[0] ); ?>" alt="<?php echo esc_attr( get_post_meta( $image_id, '_wp_attachment_image_alt', true ) ); ?>">
+                        </a>
+                    <?php endforeach; ?>
+                </div>
+            </div>
+        </section>
+        <?php endif; ?>
+
+        <?php if ( $has_video ) : ?>
+        <section id="video" class="lp-section lp-onepage-section">
+            <div class="lp-onepage-container">
+                <header class="lp-onepage-section__header">
+                    <h2><?php esc_html_e( 'Video', 'listingpro' ); ?></h2>
+                </header>
+                <div class="lp-onepage-video">
+                    <?php
+                    $video_embed = wp_oembed_get( $video_meta );
+                    if ( ! $video_embed ) {
+                        $video_embed = $video_meta;
+                    }
+                    echo wp_kses_post( $video_embed );
+                    ?>
+                </div>
+            </div>
+        </section>
+        <?php endif; ?>
+
+        <?php if ( $has_faqs ) : ?>
+        <section id="faq" class="lp-section lp-onepage-section">
+            <div class="lp-onepage-container">
+                <header class="lp-onepage-section__header">
+                    <h2><?php esc_html_e( 'Sıkça Sorulan Sorular', 'listingpro' ); ?></h2>
+                </header>
+                <div class="lp-onepage-faq">
+                    <?php
+                    $faqs = $faqs_meta['faq'];
+                    $answers = isset( $faqs_meta['faqans'] ) ? $faqs_meta['faqans'] : array();
+                    $index = 1;
+                    foreach ( $faqs as $key => $question ) {
+                        if ( empty( $question ) ) {
+                            continue;
+                        }
+                        $answer = isset( $answers[ $key ] ) ? $answers[ $key ] : '';
+                        ?>
+                        <details>
+                            <summary><?php echo esc_html( $question ); ?></summary>
+                            <div class="lp-onepage-faq__answer"><?php echo do_shortcode( wp_kses_post( $answer ) ); ?></div>
+                        </details>
+                        <?php
+                        $index++;
+                    }
+                    ?>
+                </div>
+            </div>
+        </section>
+        <?php endif; ?>
+
+        <?php if ( $has_reviews ) : ?>
+        <section id="reviews" class="lp-section lp-onepage-section">
+            <div class="lp-onepage-container">
+                <header class="lp-onepage-section__header">
+                    <h2><?php esc_html_e( 'Yorumlar', 'listingpro' ); ?></h2>
+                </header>
+                <div class="lp-onepage-reviews">
+                    <?php echo $reviews_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                </div>
+            </div>
+        </section>
+        <?php endif; ?>
+
+        <?php if ( ! empty( $latitude ) && ! empty( $longitude ) && 'true' === $map_show ) :
+            $google_key = lp_theme_option( 'google_api_key' );
+            $lat_esc = rawurlencode( $latitude );
+            $lng_esc = rawurlencode( $longitude );
+            if ( ! empty( $google_key ) ) {
+                $map_src = sprintf(
+                    'https://www.google.com/maps/embed/v1/place?key=%1$s&amp;q=%2$s,%3$s&amp;zoom=14',
+                    rawurlencode( $google_key ),
+                    $lat_esc,
+                    $lng_esc
+                );
+            } else {
+                $map_src = sprintf(
+                    'https://www.google.com/maps?q=%1$s,%2$s&amp;z=14&amp;output=embed',
+                    $lat_esc,
+                    $lng_esc
+                );
+            }
+        ?>
+        <section id="location" class="lp-section lp-onepage-section">
+            <div class="lp-onepage-container">
+                <header class="lp-onepage-section__header">
+                    <h2><?php esc_html_e( 'Konum', 'listingpro' ); ?></h2>
+                </header>
+                <div class="lp-onepage-map">
+                    <iframe src="<?php echo $map_src; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>" allowfullscreen loading="lazy"></iframe>
+                </div>
+            </div>
+        </section>
+        <?php endif; ?>
+
+        <section id="contact" class="lp-section lp-onepage-section">
+            <div class="lp-onepage-container">
+                <header class="lp-onepage-section__header">
+                    <h2><?php esc_html_e( 'İletişim', 'listingpro' ); ?></h2>
+                </header>
+                <div class="lp-onepage-contact">
+                    <ul>
+                        <?php if ( $address ) : ?>
+                            <li><strong><?php esc_html_e( 'Adres', 'listingpro' ); ?>:</strong> <?php echo esc_html( $address ); ?></li>
+                        <?php endif; ?>
+                        <?php if ( $email && 'yes' === $email_toggle ) : ?>
+                            <li><strong><?php esc_html_e( 'E-posta', 'listingpro' ); ?>:</strong> <a href="mailto:<?php echo esc_attr( $email ); ?>"><?php echo esc_html( $email ); ?></a></li>
+                        <?php endif; ?>
+                        <?php if ( $phone ) : ?>
+                            <li><strong><?php esc_html_e( 'Telefon', 'listingpro' ); ?>:</strong> <a href="tel:<?php echo esc_attr( $phone ); ?>"><?php echo esc_html( $phone ); ?></a></li>
+                        <?php endif; ?>
+                        <?php if ( $website && 'true' === $website_show ) : ?>
+                            <li><strong><?php esc_html_e( 'Web', 'listingpro' ); ?>:</strong> <a href="<?php echo esc_url( $website ); ?>" target="_blank" rel="nofollow noopener"><?php echo esc_html( $website ); ?></a></li>
+                        <?php endif; ?>
+                        <?php if ( $whatsapp ) : ?>
+                            <li><strong><?php esc_html_e( 'WhatsApp', 'listingpro' ); ?>:</strong> <a href="https://api.whatsapp.com/send?phone=<?php echo rawurlencode( $whatsapp ); ?>" target="_blank" rel="nofollow noopener"><?php echo esc_html( $whatsapp ); ?></a></li>
+                        <?php endif; ?>
+                    </ul>
+                </div>
+            </div>
         </section>
 
         <script>
         jQuery(function($){
+            var $header = $('.lp-onepage-header');
+            var headerHeight = function(){
+                return $header.outerHeight() || 0;
+            };
+            $('body').addClass('lp-onepage-active');
+
             $('.lp-onepage-nav a').on('click', function(e){
-                e.preventDefault();
-                var target = this.hash;
-                var headerHeight = $('.lp-onepage-header').outerHeight() || 0;
-                $('html, body').animate({
-                    scrollTop: $(target).offset().top - headerHeight
-                }, 500);
+                var targetId = $(this).attr('href');
+                if ( targetId.charAt(0) === '#' && $(targetId).length ) {
+                    e.preventDefault();
+                    $('html, body').animate({
+                        scrollTop: $(targetId).offset().top - headerHeight()
+                    }, 500);
+                    $('.lp-onepage-nav').removeClass('is-open');
+                    $('.lp-onepage-nav-toggle').attr('aria-expanded', 'false');
+                }
             });
+
+            $('.lp-onepage-nav-toggle').on('click', function(){
+                $('.lp-onepage-nav').toggleClass('is-open');
+                var expanded = $('.lp-onepage-nav').hasClass('is-open');
+                $(this).attr('aria-expanded', expanded ? 'true' : 'false');
+            });
+
+            var $links = $('.lp-onepage-nav a');
+            var $sections = $('.lp-section');
+            var setActiveLink = function(){
+                var scrollPos = $(window).scrollTop() + headerHeight() + 10;
+                var currentId = '';
+                $sections.each(function(){
+                    var $section = $(this);
+                    var top = $section.offset().top;
+                    var bottom = top + $section.outerHeight();
+                    if ( scrollPos >= top && scrollPos < bottom ) {
+                        currentId = $section.attr('id');
+                        return false;
+                    }
+                });
+                if ( currentId ) {
+                    $links.removeClass('is-active');
+                    $links.filter('[data-target="' + currentId + '"]').addClass('is-active');
+                }
+            };
+
+            $(window).on('scroll', setActiveLink);
+            $(window).on('load', setActiveLink);
         });
         </script>
         <?php

--- a/templates/listing-onepage.php
+++ b/templates/listing-onepage.php
@@ -33,7 +33,7 @@ if ( have_posts() ) {
         </header>
 
         <section id="home" class="lp-section lp-section-home">
-            <?php the_title('<h1 class="lp-listing-title">', '</h1>'); ?>
+            <?php the_title('<h1 class="lp-onepage-title">', '</h1>'); ?>
         </section>
 
         <?php if ( isset( $menu_items['about'] ) ) : ?>
@@ -79,8 +79,9 @@ if ( have_posts() ) {
             $('.lp-onepage-nav a').on('click', function(e){
                 e.preventDefault();
                 var target = this.hash;
+                var headerHeight = $('.lp-onepage-header').outerHeight() || 0;
                 $('html, body').animate({
-                    scrollTop: $(target).offset().top
+                    scrollTop: $(target).offset().top - headerHeight
                 }, 500);
             });
         });


### PR DESCRIPTION
## Summary
- rename the one-page template title heading to use a dedicated class
- hide the default listing header slider and share blocks when the one-page style is active

## Testing
- php -l templates/listing-onepage.php

------
https://chatgpt.com/codex/tasks/task_e_68c2bed545048323ba99f8172b07ce2f